### PR TITLE
Fixed lowercase b of LoopBack in the example

### DIFF
--- a/docs/consumers/loopback.rst
+++ b/docs/consumers/loopback.rst
@@ -20,7 +20,7 @@ Example
 
 .. code-block:: yaml
 
-  - "consumer.Loopback":
+  - "consumer.LoopBack":
     Enable: true
     Channel: 8192
     Routes:


### PR DESCRIPTION
Using consumer.Loopback will cause in a type-error when starting gollum. Actual name of the consumer is consumer.LoopBack