### PR TITLE
fix kinesis consumer to respect DefaultOffset

### DIFF
--- a/consumer/kinesis.go
+++ b/consumer/kinesis.go
@@ -192,7 +192,6 @@ func (cons *Kinesis) Configure(conf core.PluginConfig) error {
 		if err != nil {
 			return err
 		}
-		cons.offsetType = kinesis.ShardIteratorTypeAfterSequenceNumber
 		if err := json.Unmarshal(fileContents, &cons.offsets); err != nil {
 			return err
 		}
@@ -210,6 +209,9 @@ func (cons *Kinesis) processShard(shardID string) {
 	}
 	if *iteratorConfig.StartingSequenceNumber == "" {
 		iteratorConfig.StartingSequenceNumber = nil
+	} else {
+		// starting sequence number requires ShardIteratorTypeAfterSequenceNumber
+		iteratorConfig.ShardIteratorType = aws.String(kinesis.ShardIteratorTypeAfterSequenceNumber)
 	}
 
 	iterator, err := cons.client.GetShardIterator(&iteratorConfig)


### PR DESCRIPTION
Currently if `DefaultOffest` configuration is set to `newest` or `oldest`, and `OffsetFile` points to a file that does not contain all of the current kinesis shards then:
<pre>
iterator, err := cons.client.GetShardIterator(&iteratorConfig)
</pre>
will fail, with the following error:
<pre>
InvalidArgumentException: Must either specify (1) AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER and StartingSequenceNumber or (2) TRIM_HORIZON or LATEST and no StartingSequenceNumber. Request specified AFTER_SEQUENCE_NUMBER and no StartingSequenceNumber.
</pre>

With this patch the `DefaultOffset` will be respected on new shards, while shards found in the `OffsetFile` will use `ShardIteratorTypeAfterSequenceNumber`.