### PR TITLE
allow kinesis records to contain multiple messages

### DIFF
--- a/producer/kinesis.go
+++ b/producer/kinesis.go
@@ -50,6 +50,8 @@ const (
 //    CredentialFile: ""
 //    CredentialProfile: ""
 //    BatchMaxMessages: 500
+//    RecordMaxMessages: 1
+//    RecordMessageDelimiter: "\n"
 //    SendTimeframeSec: 1
 //    BatchTimeoutSec: 3
 //    StreamMapping:
@@ -76,6 +78,12 @@ const (
 // BatchMaxMessages defines the maximum number of messages to send per
 // batch. By default this is set to 500.
 //
+// RecordMaxMessages defines the maximum number of messages to join into
+// a kinesis record. By default this is set to 500.
+//
+// RecordMessageDelimiter defines the string to delimit messages within
+// a kinesis record. By default this is set to "\n".
+//
 // SendTimeframeMs defines the timeframe in milliseconds in which a second
 // batch send can be triggered. By default this is set to 1000, i.e. one
 // send operation per second.
@@ -88,15 +96,17 @@ const (
 // stream name.
 type Kinesis struct {
 	core.ProducerBase
-	client           *kinesis.Kinesis
-	config           *aws.Config
-	streamMap        map[core.MessageStreamID]string
-	batch            core.MessageBatch
-	flushFrequency   time.Duration
-	lastSendTime     time.Time
-	sendTimeLimit    time.Duration
-	counters         map[string]*int64
-	lastMetricUpdate time.Time
+	client            *kinesis.Kinesis
+	config            *aws.Config
+	streamMap         map[core.MessageStreamID]string
+	batch             core.MessageBatch
+	recordMaxMessages int
+	delimiter         []byte
+	flushFrequency    time.Duration
+	lastSendTime      time.Time
+	sendTimeLimit     time.Duration
+	counters          map[string]*int64
+	lastMetricUpdate  time.Time
 }
 
 const (
@@ -105,8 +115,9 @@ const (
 )
 
 type streamData struct {
-	content  *kinesis.PutRecordsInput
-	original []*core.Message
+	content            *kinesis.PutRecordsInput
+	original           [][]*core.Message
+	lastRecordMessages int
 }
 
 func init() {
@@ -123,6 +134,8 @@ func (prod *Kinesis) Configure(conf core.PluginConfig) error {
 
 	prod.streamMap = conf.GetStreamMap("StreamMapping", "default")
 	prod.batch = core.NewMessageBatch(conf.GetInt("BatchMaxMessages", 500))
+	prod.recordMaxMessages = conf.GetInt("RecordMaxMessages", 1)
+	prod.delimiter = []byte(conf.GetString("RecordMessageDelimiter", "\n"))
 	prod.flushFrequency = time.Duration(conf.GetInt("BatchTimeoutSec", 3)) * time.Second
 	prod.sendTimeLimit = time.Duration(conf.GetInt("SendTimeframeMs", 1000)) * time.Millisecond
 	prod.lastSendTime = time.Now()
@@ -231,19 +244,33 @@ func (prod *Kinesis) transformMessages(messages []core.Message) {
 					Records:    make([]*kinesis.PutRecordsRequestEntry, 0, len(messages)),
 					StreamName: aws.String(streamName),
 				},
-				original: make([]*core.Message, 0, len(messages)),
+				original: make([][]*core.Message, 0, len(messages) / prod.recordMaxMessages + 1),
+				lastRecordMessages: 0,
 			}
 			streamRecords[streamID] = records
 		}
 
-		// Append record to stream
-		record := &kinesis.PutRecordsRequestEntry{
-			Data:         msgData,
-			PartitionKey: aws.String(messageHash),
+		// Fetch record for this buffer
+		var record *kinesis.PutRecordsRequestEntry
+		recordExists := len(records.content.Records) > 0
+		if !recordExists || records.lastRecordMessages + 1 > prod.recordMaxMessages {
+			// Append record to stream
+			record = &kinesis.PutRecordsRequestEntry{
+				Data:         make([]byte, 0, len(msgData)),
+				PartitionKey: aws.String(messageHash),
+			}
+			records.content.Records = append(records.content.Records, record)
+			records.original = append(records.original, make([]*core.Message, 0, prod.recordMaxMessages))
+			records.lastRecordMessages = 0
+		} else {
+			record = records.content.Records[len(records.content.Records)-1]
+			record.Data = append(record.Data, prod.delimiter...)
 		}
 
-		records.content.Records = append(records.content.Records, record)
-		records.original = append(records.original, &messages[idx])
+		// Append message to record
+		record.Data = append(record.Data, msgData...)
+		records.lastRecordMessages += 1
+		records.original[len(records.original)-1] = append(records.original[len(records.original)-1], &messages[idx])
 	}
 
 	sleepDuration := prod.sendTimeLimit - time.Since(prod.lastSendTime)
@@ -259,15 +286,19 @@ func (prod *Kinesis) transformMessages(messages []core.Message) {
 		if err != nil {
 			// Batch failed, drop all
 			Log.Error.Print("Kinesis write error: ", err)
-			for _, msg := range records.original {
-				prod.Drop(*msg)
+			for _, messages := range records.original {
+				for _, msg := range messages {
+					prod.Drop(*msg)
+				}
 			}
 		} else {
 			// Check each message for errors
 			for msgIdx, record := range result.Records {
 				if record.ErrorMessage != nil {
 					Log.Error.Print("Kinesis message write error: ", *record.ErrorMessage)
-					prod.Drop(*records.original[msgIdx])
+					for _, msg := range records.original[msgIdx] {
+						prod.Drop(*msg)
+					}
 				}
 			}
 		}

--- a/producer/kinesis.go
+++ b/producer/kinesis.go
@@ -51,7 +51,7 @@ const (
 //    CredentialProfile: ""
 //    BatchMaxMessages: 500
 //    RecordMaxMessages: 1
-//    RecordMessageDelimiter: "\n"
+//    RecordMessageDelimiter: ""
 //    SendTimeframeSec: 1
 //    BatchTimeoutSec: 3
 //    StreamMapping:
@@ -82,7 +82,7 @@ const (
 // a kinesis record. By default this is set to 500.
 //
 // RecordMessageDelimiter defines the string to delimit messages within
-// a kinesis record. By default this is set to "\n".
+// a kinesis record. By default this is set to "".
 //
 // SendTimeframeMs defines the timeframe in milliseconds in which a second
 // batch send can be triggered. By default this is set to 1000, i.e. one
@@ -141,6 +141,16 @@ func (prod *Kinesis) Configure(conf core.PluginConfig) error {
 	prod.lastSendTime = time.Now()
 	prod.counters = make(map[string]*int64)
 	prod.lastMetricUpdate = time.Now()
+
+	if prod.recordMaxMessages < 1 {
+        prod.recordMaxMessages = 1
+		Log.Warning.Print("RecordMaxMessages was < 1. Defaulting to 1.")
+	}
+
+	if prod.recordMaxMessages > 1 && len(prod.delimiter) == 0 {
+        prod.delimiter = []byte("\n")
+		Log.Warning.Print("RecordMessageDelimiter was empty. Defaulting to \"\\n\".")
+	}
 
 	// Config
 	prod.config = aws.NewConfig()


### PR DESCRIPTION
currently the kinesis producer creates a kinesis record for each gollum message, and the consumer creates a gollum message for each kinesis record.

With this patch, the producer can optionally join multiple gollum messages into a single kinesis record, and the consumer can split kinesis records into multiple gollum messages.

Aggregating messages like this is desirable because records are rounded up to the next 25KB when determining cost and each shard in a stream is limited to 1K record/s or 1MB/s.