### PR TITLE
Fix typos found by goreportcard.com

### DIFF
--- a/consumer/kinesis.go
+++ b/consumer/kinesis.go
@@ -173,7 +173,7 @@ func (cons *Kinesis) Configure(conf core.PluginConfig) error {
 		// Nothing
 
 	default:
-		return fmt.Errorf("Unknwon CredentialType: %s", credentialType)
+		return fmt.Errorf("Unknown CredentialType: %s", credentialType)
 	}
 
 	// Offset

--- a/core/consumer.go
+++ b/core/consumer.go
@@ -276,31 +276,31 @@ func (cons *ConsumerBase) ControlLoop() {
 		command := <-cons.control
 		switch command {
 		default:
-			Log.Debug.Print("Recieved untracked command")
+			Log.Debug.Print("Received untracked command")
 			// Do nothing
 
 		case PluginControlStopConsumer:
 			cons.setState(PluginStateStopping)
-			Log.Debug.Print("Recieved stop command")
+			Log.Debug.Print("Received stop command")
 			if cons.onStop != nil {
 				cons.onStop()
 			}
 			return // ### return ###
 
 		case PluginControlRoll:
-			Log.Debug.Print("Recieved roll command")
+			Log.Debug.Print("Received roll command")
 			if cons.onRoll != nil {
 				cons.onRoll()
 			}
 
 		case PluginControlFuseBurn:
-			Log.Debug.Print("Recieved fuse burned command")
+			Log.Debug.Print("Received fuse burned command")
 			if cons.onFuseBurned != nil {
 				cons.onFuseBurned()
 			}
 
 		case PluginControlFuseActive:
-			Log.Debug.Print("Recieved fuse active command")
+			Log.Debug.Print("Received fuse active command")
 			if cons.onFuseActive != nil {
 				cons.onFuseActive()
 			}

--- a/core/producer.go
+++ b/core/producer.go
@@ -538,11 +538,11 @@ func (prod *ProducerBase) ControlLoop() {
 		command := <-prod.control
 		switch command {
 		default:
-			Log.Debug.Print("Recieved untracked command")
+			Log.Debug.Print("Received untracked command")
 			// Do nothing
 
 		case PluginControlStopProducer:
-			Log.Debug.Print("Recieved stop command")
+			Log.Debug.Print("Received stop command")
 			prod.WaitForDependencies(PluginStateDead, prod.GetShutdownTimeout())
 			prod.setState(PluginStateStopping)
 			Log.Debug.Print("All dependencies resolved")
@@ -553,7 +553,7 @@ func (prod *ProducerBase) ControlLoop() {
 			return // ### return ###
 
 		case PluginControlRoll:
-			Log.Debug.Print("Recieved roll command")
+			Log.Debug.Print("Received roll command")
 			if prod.onRoll != nil {
 				prod.onRoll()
 			}

--- a/core/writerassembly.go
+++ b/core/writerassembly.go
@@ -44,7 +44,7 @@ func NewWriterAssembly(writer io.Writer, flush func(Message), formatter Formatte
 	}
 }
 
-// SetValidator sets a callback that is called if a write was successfull.
+// SetValidator sets a callback that is called if a write was successful.
 // Validate needs to return true to prevent messages to be flushed.
 func (asm *WriterAssembly) SetValidator(validate func() bool) {
 	asm.validate = validate

--- a/core/writerassembly_test.go
+++ b/core/writerassembly_test.go
@@ -83,7 +83,7 @@ func TestWriterAssemblyWrite(t *testing.T) {
 
 	msg1 := NewMessage(nil, []byte("abcde"), 0)
 
-	// should give error msg and flush msg as ther writer is not available yet
+	// should give error msg and flush msg as there writer is not available yet
 	// test here is done in mockIo.mockFlush
 	wa.Write([]Message{msg1})
 

--- a/filter/rate.go
+++ b/filter/rate.go
@@ -42,7 +42,7 @@ import (
 // limit is reached. By default this is disabled and set to "".
 //
 // RateLimitIgnore defines a list of streams that should not be affected by
-// rate limiting. This is usefull for e.g. producers listeing to "*".
+// rate limiting. This is useful for e.g. producers listeing to "*".
 // By default this list is empty.
 type Rate struct {
 	rateLimit    int64

--- a/format/streamname.go
+++ b/format/streamname.go
@@ -33,7 +33,7 @@ import (
 // message. By default this is set to "format.Envelope"
 //
 // StreamNameHistory can be set to true to not use the current but the previous
-// stream name. This can be usefull to e.g. get the name of the stream messages
+// stream name. This can be useful to e.g. get the name of the stream messages
 // were dropped from. By default this is set to false.
 //
 // StreamNameSeparator sets the separator character placed after the stream name.

--- a/producer/elasticsearch.go
+++ b/producer/elasticsearch.go
@@ -68,7 +68,7 @@ import (
 // is used as the server passed to the "Domain" setting. The Domain setting can
 // be overwritten, too.
 //
-// Port defines the elasticsearch port, wich has to be the same for all servers.
+// Port defines the elasticsearch port, which has to be the same for all servers.
 // By default this is set to 9200.
 //
 // User and Password can be used to pass credentials to the elasticsearch server.

--- a/producer/kafka.go
+++ b/producer/kafka.go
@@ -104,7 +104,7 @@ const (
 // BatchSizeMaxKB defines the maximum allowed message size. By default this is
 // set to 1024.
 //
-// BatchTimeoutMs sets the minimum time in milliseconds to pass after wich a new
+// BatchTimeoutMs sets the minimum time in milliseconds to pass after which a new
 // flush will be triggered. By default this is set to 3.
 //
 // MessageBufferCount sets the internal channel size for the kafka client.

--- a/shared/trie.go
+++ b/shared/trie.go
@@ -15,7 +15,7 @@
 package shared
 
 // TrieNode represents a single node inside a trie.
-// Each node can contain a payload which can be retrieved after a successfull
+// Each node can contain a payload which can be retrieved after a successful
 // match. In addition to that PathLen will contain the length of the match.
 type TrieNode struct {
 	suffix      []byte


### PR DESCRIPTION
The current goreportcard reports a few typos. See https://goreportcard.com/report/github.com/trivago/gollum#misspell

This PR fix this typos.