### PR TITLE
Fix Dockerfile to be able to build gollum image again.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ COPY . /go/src/github.com/trivago/gollum
 
 RUN make
 
-ENTRYPOINT ["/go/src/gollum/gollum"]
+RUN chmod +x /go/src/github.com/trivago/gollum/gollum
+
+ENTRYPOINT ["/go/src/github.com/trivago/gollum/gollum"]


### PR DESCRIPTION
The Dockerfile is quite old. So it needs to get updated a bit.
This change includes the correct gollum path and introduced the filepermission change to be able to execute the gollum binary.