### PR TITLE
Added verbose info in order to investigate reasons of exception

### DIFF
--- a/consumer/kafka.go
+++ b/consumer/kafka.go
@@ -468,6 +468,18 @@ func (cons *Kafka) readFromPartition(partitionID int32) {
 
 		select {
 		case event := <-partCons.Messages():
+			//Added some verbose information so that we can investigate reasons of
+			//exception. Probably it might happen when sarama close the channel
+			//so we will get nil message from the channel.
+			if event == nil || cons.offsets == nil || cons.offsets[partitionID] == nil {
+				Log.Error.Printf("Kafka consumer failed to store offset. Trace : event : %+v, cons.partCons: %+v, partitionID: %d\n", 
+					event, cons.offsets, partitionID)
+
+				partCons.Close()
+				partCons = cons.startConsumerForPartition(partitionID)
+				continue
+			}
+
 			atomic.StoreInt64(cons.offsets[partitionID], event.Offset)
 			sequence := atomic.AddUint64(cons.sequence, 1) - 1
 			if cons.prependKey {


### PR DESCRIPTION
Added some verbose information so that we can investigate reasons of the following exception. Probably it might happen when sarama suddenly close the channel so we get nil message from the channel.
```bash
goroutine 24 [running]:
panic(0xaa0620, 0xc420010040)
    /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/trivago/gollum/consumer.(*Kafka).readFromPartition(0xc42015dc20, 0xc400000000)
    /.../src/github.com/trivago/gollum/consumer/kafka.go:471 +0x240
created by github.com/trivago/gollum/consumer.(*Kafka).startReadTopic
    /.../src/github.com/trivago/gollum/consumer/kafka.go:561 +0x183
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x48d3c0]
```
