### PR TITLE
Fix format.ProcessJSONs flatten directive

### DIFF
--- a/format/processjson.go
+++ b/format/processjson.go
@@ -264,9 +264,9 @@ func processDirective(directive transformDirective, values *shared.MarshalMap) {
 				delimiter = directive.parameters[0]
 			}
 			keyPrefix := directive.key + delimiter
-			if mapValue, err := values.Map(directive.key); err == nil {
+			if mapValue, err := values.MarshalMap(directive.key); err == nil {
 				for key, val := range mapValue {
-					(*values)[keyPrefix + key.(string)] = val
+					(*values)[keyPrefix + key] = val
 				}
 			} else if arrayValue, err := values.Array(directive.key); err == nil {
 				for index, val := range arrayValue {


### PR DESCRIPTION
without this format.ProcessJSON would fail to flatten keys containing json objects, because json objects must be cast to `map[string]interface{}` instead of `map[interface{}]interface{}`