### PR TITLE
websocket: Adding IgnoreOrigin and minor bug fix

### DIFF
--- a/config/http_to_ws.conf
+++ b/config/http_to_ws.conf
@@ -10,3 +10,4 @@
 - "producer.Websocket":
     Enable: true
     Address: "localhost:8080"
+    IgnoreOrigin: true

--- a/docs/producers/websocket.rst
+++ b/docs/producers/websocket.rst
@@ -75,6 +75,10 @@ Parameters
   ReadTimeoutSec specifies the maximum duration in seconds before timing out read of the request.
   By default this is set to 3 seconds.
 
+**IgnoreOrigin**
+  IgnoreOrigin disables the Origin header check and allows connections from any remote host.
+  By default this is set to false.
+
 Example
 -------
 
@@ -97,3 +101,4 @@ Example
 	    Address: ":81"
 	    Path:    "/"
 	    ReadTimeoutSec: 3
+        IgnoreOrigin: false


### PR DESCRIPTION
Run into an issue with the websocket server Origin default check. So added a flag to disable it. Also fixed an issue in case a connection upgrade fails.