### PR TITLE
Updated aws kinesis config documentation

### DIFF
--- a/consumer/kinesis.go
+++ b/consumer/kinesis.go
@@ -84,7 +84,7 @@ const (
 // By default this is set to none.
 //
 // DefaultOffset defines the message index to start reading from.
-// Valid values are either "Newset", "Oldest", or a number.
+// Valid values are either "Newest", "Oldest", or a number.
 // The default value is "Newest".
 //
 // OffsetFile defines a file to store the current offset per shard.

--- a/docs/consumers/kinesis.rst
+++ b/docs/consumers/kinesis.rst
@@ -48,8 +48,8 @@ Parameters
 
 **DefaultOffset**
   DefaultOffset defines the message index to start reading from.
-  Valid values are either "Newset", "Oldest", or a number.
-  The default value is "Newest".
+  Valid values are either "newest", "oldest", or a number.
+  The default value is "newest".
 
 **OffsetFile**
   OffsetFile defines a file to store the current offset per shard.
@@ -87,7 +87,7 @@ Example
 	    KinesisStream: "default"
 	    Region: "eu-west-1"
 	    Endpoint: "kinesis.eu-west-1.amazonaws.com"
-	    DefaultOffset: "Newest"
+	    DefaultOffset: "newest"
 	    OffsetFile: ""
 	    RecordsPerQuery: 100
 	    RecordMessageDelimiter: ""


### PR DESCRIPTION
Looking at the code, i think these args should be lowercase, right?

(also fixed a typo newset -> newest)