### PR TITLE
fix undefined: body in http consumer

### DIFF
--- a/consumer/http.go
+++ b/consumer/http.go
@@ -167,7 +167,7 @@ func (cons *Http) requestHandler(resp http.ResponseWriter, req *http.Request) {
 			return // ### return, missing body ###
 		}
 
-		body, err = ioutil.ReadAll(req.Body)
+		body, err := ioutil.ReadAll(req.Body)
 		if err != nil {
 			resp.WriteHeader(http.StatusBadRequest)
 			Log.Error.Print("HttpRequest: ", err.Error())


### PR DESCRIPTION
Fixed "undefined: body" in consumer/http.go

```
GoWork/src/github.com/trivago/gollum$ go build
# github.com/trivago/gollum/consumer
consumer/http.go:170: undefined: body
consumer/http.go:170: undefined: err
consumer/http.go:171: undefined: err
consumer/http.go:173: undefined: err in err.Error
consumer/http.go:178: undefined: body

```