### PR TITLE
Decrease grok verbosity in case of parse errors

### DIFF
--- a/format/groktojson.go
+++ b/format/groktojson.go
@@ -96,6 +96,6 @@ func (format *GrokToJSON) applyGrok(content string) (map[string]string, error) {
 			return values, nil
 		}
 	}
-	format.Logger.Errorf("Message does not match any pattern: %s", content)
+	format.Logger.Warningf("Message does not match any pattern: %s", content)
 	return nil, fmt.Errorf("Grok parsing error")
 }


### PR DESCRIPTION
Turns out the grok formatter can become quite verbose when handling lots of invalid data.
By setting the log level to "warning", we at least allow the user to set the log level to 0 and ignore the messages. 