### PR TITLE
Fix for #148 blocking distribute

### DIFF
--- a/router/distribute.go
+++ b/router/distribute.go
@@ -91,7 +91,6 @@ func (router *Distribute) Start() error {
 		targetRouter := core.StreamRegistry.GetRouterOrFallback(streamID)
 		router.routers = append(router.routers, targetRouter)
 	}
-
 	return nil
 }
 
@@ -101,7 +100,6 @@ func (router *Distribute) route(msg *core.Message, targetRouter core.Router) {
 	} else {
 		msg.SetStreamID(targetRouter.GetStreamID())
 		core.Route(msg, targetRouter)
-		router.Logger.Debugf("routed to StreamID '%v'", targetRouter.GetStreamID())
 	}
 }
 


### PR DESCRIPTION
The bug reported in issue #148 was caused by a log message being triggered by a log message in an infinite loop. To prevent this all log messages are now sent to a channel that is processed asynchronously in the event loop of core.logConsumer.  
This will slow down gollum at worst but it will not be stuck in an infinite loop anymore.
  
During shutdown (after the channel is closed) all messages will be forwarded to the logger.FallbackLogDevice so that no log messages get lost.