### PR TITLE
Fix for #103 Enabled shared config sessions for all AWS related plugins

### DIFF
--- a/consumer/kinesis.go
+++ b/consumer/kinesis.go
@@ -296,7 +296,14 @@ func (cons *Kinesis) processShard(shardID string) {
 }
 
 func (cons *Kinesis) connect() error {
-	cons.client = kinesis.New(session.New(cons.config))
+	session, err := session.NewSessionWithOptions(session.Options{
+		Config:            *cons.config,
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		return err
+	}
+	cons.client = kinesis.New(session)
 
 	// Get shard ids for stream
 	streamQuery := &kinesis.DescribeStreamInput{

--- a/consumer/kinesis.go
+++ b/consumer/kinesis.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/trivago/gollum/core"
@@ -117,6 +118,7 @@ type Kinesis struct {
 	sleepTime           time.Duration `config:"QuerySleepTimeMs" default:"1000" metric:"ms"`
 	retryTime           time.Duration `config:"RetrySleepTimeSec" default:"4" metric:"sec"`
 	shardTime           time.Duration `config:"CheckNewShardsSec" default:"0" metric:"sec"`
+	assumeRole          string        `config:"Credential/AssumeRole"`
 	running             bool
 }
 
@@ -145,7 +147,7 @@ func (cons *Kinesis) Configure(conf core.PluginConfigReader) {
 		cons.config.WithCredentials(credentials.NewEnvCredentials())
 
 	case kinesisCredentialStatic:
-		id := conf.GetString("Credentia/lId", "")
+		id := conf.GetString("Credential/Id", "")
 		token := conf.GetString("Credential/Token", "")
 		secret := conf.GetString("Credential/Secret", "")
 		cons.config.WithCredentials(credentials.NewStaticCredentials(id, secret, token))
@@ -296,14 +298,20 @@ func (cons *Kinesis) processShard(shardID string) {
 }
 
 func (cons *Kinesis) connect() error {
-	session, err := session.NewSessionWithOptions(session.Options{
+	sess, err := session.NewSessionWithOptions(session.Options{
 		Config:            *cons.config,
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {
 		return err
 	}
-	cons.client = kinesis.New(session)
+
+	if cons.assumeRole != "" {
+		creds := stscreds.NewCredentials(sess, cons.assumeRole)
+		cons.client = kinesis.New(sess, &aws.Config{Credentials: creds})
+	} else {
+		cons.client = kinesis.New(sess)
+	}
 
 	// Get shard ids for stream
 	streamQuery := &kinesis.DescribeStreamInput{

--- a/consumer/kinesis.go
+++ b/consumer/kinesis.go
@@ -141,6 +141,7 @@ func (cons *Kinesis) Configure(conf core.PluginConfigReader) {
 	}
 
 	// Credentials
+	cons.config.CredentialsChainVerboseErrors = aws.Bool(true)
 	credentialType := strings.ToLower(conf.GetString("Credential/Type", kinesisCredentialNone))
 	switch credentialType {
 	case kinesisCredentialEnv:

--- a/producer/firehose.go
+++ b/producer/firehose.go
@@ -311,7 +311,14 @@ func (prod *Firehose) close() {
 // Produce writes to stdout or stderr.
 func (prod *Firehose) Produce(workers *sync.WaitGroup) {
 	prod.AddMainWorker(workers)
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config:            *prod.config,
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		prod.Logger.WithError(err).Error("Failed to create session")
+	}
 
-	prod.client = firehose.New(session.New(prod.config))
+	prod.client = firehose.New(sess)
 	prod.TickerMessageControlLoop(prod.bufferMessage, prod.flushFrequency, prod.sendBatchOnTimeOut)
 }

--- a/producer/kinesis.go
+++ b/producer/kinesis.go
@@ -153,6 +153,7 @@ func (prod *Kinesis) Configure(conf core.PluginConfigReader) {
 	}
 
 	// Credentials
+	prod.config.CredentialsChainVerboseErrors = aws.Bool(true)
 	credentialType := strings.ToLower(conf.GetString("Credential/Type", kinesisCredentialNone))
 	switch credentialType {
 	case kinesisCredentialEnv:
@@ -261,7 +262,7 @@ func (prod *Kinesis) transformMessages(messages []*core.Message) {
 
 		if err != nil {
 			// Batch failed, fallback all
-			prod.Logger.Error("Write error: ", err)
+			prod.Logger.WithError(err).Error("Failed to put records")
 			for _, messages := range records.original {
 				for _, msg := range messages {
 					prod.TryFallback(msg)

--- a/producer/kinesis.go
+++ b/producer/kinesis.go
@@ -281,6 +281,14 @@ func (prod *Kinesis) transformMessages(messages []*core.Message) {
 
 // Produce writes to stdout or stderr.
 func (prod *Kinesis) Produce(workers *sync.WaitGroup) {
-	prod.client = kinesis.New(session.New(prod.config))
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config:            *prod.config,
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		prod.Logger.WithError(err).Error("Failed to create session")
+	}
+
+	prod.client = kinesis.New(sess)
 	prod.BatchMessageLoop(workers, prod.sendBatch)
 }

--- a/producer/s3.go
+++ b/producer/s3.go
@@ -591,7 +591,14 @@ func (prod *S3) close() {
 // Produce writes to a buffer that is sent to amazon s3.
 func (prod *S3) Produce(workers *sync.WaitGroup) {
 	prod.AddMainWorker(workers)
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config:            *prod.config,
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		prod.Logger.WithError(err).Error("Failed to create session")
+	}
 
-	prod.client = s3.New(session.New(prod.config))
+	prod.client = s3.New(sess)
 	prod.TickerMessageControlLoop(prod.bufferMessage, prod.flushFrequency, prod.sendBatchOnTimeOut)
 }


### PR DESCRIPTION
This change will allow gollum to be started like this:

```bash
AWS_DEFAULT_PROFILE=foobar gollum -c ...
```

This fixes #103 with a known way to change roles.