### PR TITLE
Fix for #151 config validation on startup

### DIFF
--- a/coordinator.go
+++ b/coordinator.go
@@ -130,7 +130,7 @@ func (co *Coordinator) StartPlugins() {
 	if core.StreamRegistry.IsStreamRegistered(core.LogInternalStreamID) {
 		// The _GOLLUM_ stream has listeners, so use LogConsumer to write to it
 		if *flagLogColors != "always" {
-			logrus.SetFormatter(&logrus.TextFormatter{})
+			logrus.SetFormatter(logger.NewConsoleFormatter())
 		}
 		logrusHookBuffer.SetTargetHook(co.logConsumer)
 		logrusHookBuffer.Purge()

--- a/coordinator.go
+++ b/coordinator.go
@@ -71,9 +71,8 @@ func NewCoordinator() Coordinator {
 
 // Configure processes the config and instantiates all valid plugins
 func (co *Coordinator) Configure(conf *core.Config) error {
-	// Make sure the log is printed to stderr if we are stuck here
+	// Make sure the log is printed to the fallback device if we are stuck here
 	logFallback := time.AfterFunc(time.Duration(3)*time.Second, func() {
-		//logrus.SetOutput(os.Stderr)
 		logrusHookBuffer.SetTargetWriter(logger.FallbackLogDevice)
 		logrusHookBuffer.Purge()
 	})

--- a/coordinator.go
+++ b/coordinator.go
@@ -202,8 +202,12 @@ func (co *Coordinator) Shutdown() {
 func (co *Coordinator) configureRouters(conf *core.Config) {
 	routerConfigs := conf.GetRouters()
 	for _, config := range routerConfigs {
-		logrus.Debugf("Instantiating router '%s'", config.ID)
+		if _, hasStreams := config.Settings.Value("stream"); !hasStreams {
+			logrus.Errorf("Router '%s' has no stream set", config.ID)
+			continue // ### continue ###
+		}
 
+		logrus.Debugf("Instantiating router '%s'", config.ID)
 		plugin, err := core.NewPluginWithConfig(config)
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to instantiate router '%s'", config.ID)

--- a/core/config.go
+++ b/core/config.go
@@ -116,18 +116,19 @@ func (err PluginConfigError) Error() string {
 // Validate checks all plugin configs and plugins on validity. I.e. it checks
 // on mandatory fields and correct implementation of consumer, producer or
 // stream interface. It does NOT call configure for each plugin.
-func (conf *Config) Validate() []error {
+func (conf *Config) Validate() error {
 	errors := tgo.NewErrorStack()
+	errors.SetFormat(tgo.ErrorStackFormatCSV)
 
 	for _, config := range conf.Plugins {
 		if config.Typename == "" {
-			errors.Push(newPluginConfigError(config.ID, "", "Plugin type is not set."))
+			errors.Push(newPluginConfigError(config.ID, "", "Plugin type is not set"))
 			continue
 		}
 
 		pluginType := TypeRegistry.GetTypeOf(config.Typename)
 		if pluginType == nil {
-			errors.Push(newPluginConfigError(config.ID, config.Typename, "Type not registered. Please check compiled plugins."))
+			errors.Push(newPluginConfigError(config.ID, config.Typename, "Type not registered. Please check compiled plugins"))
 			continue // ### continue ###
 		}
 
@@ -142,11 +143,11 @@ func (conf *Config) Validate() []error {
 			continue
 		}
 
-		errors.Push(newPluginConfigError(config.ID, config.Typename, "Type does not implement a common interface."))
+		errors.Push(newPluginConfigError(config.ID, config.Typename, "Type does not implement a common interface"))
 		getClosestMatch(pluginType, &errors)
 	}
 
-	return errors.Errors()
+	return errors.OrNil()
 }
 
 // GetConsumers returns all consumer plugins from the config

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -97,8 +97,8 @@ func TestValidate(t *testing.T) {
 	conf, err := ReadConfig(testConfig)
 	expect.NoError(err)
 
-	errors := conf.Validate()
-	expect.Equal(0, len(errors))
+	err = conf.Validate()
+	expect.NoError(err)
 }
 
 func TestValidateFailure(t *testing.T) {
@@ -109,6 +109,6 @@ func TestValidateFailure(t *testing.T) {
 	conf, err := ReadConfig(testConfig)
 	expect.NoError(err)
 
-	errors := conf.Validate()
-	expect.Equal(1, len(errors))
+	err = conf.Validate()
+	expect.NotNil(err)
 }

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -152,7 +152,7 @@ func (state *PluginRunState) WorkerDone() {
 // NewPluginWithConfig creates a new plugin from the type information stored in its
 // config. This function internally calls NewPluginWithType.
 func NewPluginWithConfig(config PluginConfig) (Plugin, error) {
-	if config.Typename == "" {
+	if len(config.Typename) == 0 {
 		return nil, fmt.Errorf("Plugin '%s' has no type set", config.ID)
 	}
 
@@ -167,16 +167,19 @@ func NewPluginWithConfig(config PluginConfig) (Plugin, error) {
 	}
 
 	reader := NewPluginConfigReader(&config)
-	err = reader.Configure(plugin)
-	if err == nil {
-		if config.ID != "" {
-			// If an id is set it must be unique
-			PluginRegistry.RegisterUnique(plugin, config.ID)
-		}
-
-		// Check for errors (log as warning)
-		config.Validate()
+	if err := reader.Configure(plugin); err != nil {
+		return nil, err
 	}
 
-	return plugin, err
+	// Note: The current YAML format does actually prevent this, but left here
+	//       as a precaution.
+	if len(config.ID) > 0 && !PluginRegistry.RegisterUnique(plugin, config.ID) {
+		return nil, fmt.Errorf("Plugin id '%s' must be unique", config.ID)
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return plugin, nil
 }

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -152,6 +152,11 @@ func (state *PluginRunState) WorkerDone() {
 // NewPluginWithConfig creates a new plugin from the type information stored in its
 // config. This function internally calls NewPluginWithType.
 func NewPluginWithConfig(config PluginConfig) (Plugin, error) {
+	fmt.Println(config.ID, config.Typename)
+	if config.Typename == "" {
+		return nil, fmt.Errorf("Plugin '%s' has no type set", config.ID)
+	}
+
 	obj, err := TypeRegistry.New(config.Typename)
 	if err != nil {
 		return nil, err
@@ -159,7 +164,7 @@ func NewPluginWithConfig(config PluginConfig) (Plugin, error) {
 
 	plugin, isPlugin := obj.(Plugin)
 	if !isPlugin {
-		return nil, fmt.Errorf("%s is not a plugin type", config.Typename)
+		return nil, fmt.Errorf("'%s' is not a plugin type", config.Typename)
 	}
 
 	reader := NewPluginConfigReader(&config)

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -152,7 +152,6 @@ func (state *PluginRunState) WorkerDone() {
 // NewPluginWithConfig creates a new plugin from the type information stored in its
 // config. This function internally calls NewPluginWithType.
 func NewPluginWithConfig(config PluginConfig) (Plugin, error) {
-	fmt.Println(config.ID, config.Typename)
 	if config.Typename == "" {
 		return nil, fmt.Errorf("Plugin '%s' has no type set", config.ID)
 	}

--- a/core/pluginconfig.go
+++ b/core/pluginconfig.go
@@ -92,16 +92,16 @@ func (conf *PluginConfig) registerKey(key string) string {
 
 // Validate should be called after a configuration has been processed. It will
 // check the keys read from the config files against the keys requested up to
-// this point. Unknown keys will be written to the error log.
-func (conf PluginConfig) Validate() bool {
-	valid := true
+// this point. Unknown keys will be returned as errors
+func (conf PluginConfig) Validate() error {
+	errors := tgo.NewErrorStack()
+	errors.SetFormat(tgo.ErrorStackFormatCSV)
 	for key := range conf.Settings {
 		if _, exists := conf.validKeys[key]; !exists {
-			valid = false
-			logrus.Warningf("Unknown configuration key in %s: %s", conf.Typename, key)
+			errors.Pushf("Unknown configuration key in %s: %s", conf.Typename, key)
 		}
 	}
-	return valid
+	return errors.OrNil()
 }
 
 // Read analyzes a given key/value map to extract the configuration values valid
@@ -110,6 +110,7 @@ func (conf PluginConfig) Validate() bool {
 func (conf *PluginConfig) Read(values tcontainer.MarshalMap) error {
 	var err error
 	errors := tgo.NewErrorStack()
+	errors.SetFormat(tgo.ErrorStackFormatCSV)
 	for key, settingValue := range values {
 		lowerCaseKey := strings.ToLower(key)
 

--- a/core/pluginconfig_test.go
+++ b/core/pluginconfig_test.go
@@ -39,13 +39,15 @@ func TestPluginConfigValidate(t *testing.T) {
 	sValue, err := mockPluginCfgReader.GetString("stringKey", "")
 	expect.NoError(err)
 	expect.Equal(sValue, "value")
-	expect.True(mockPluginCfg.Validate())
+	err = mockPluginCfg.Validate()
+	expect.NoError(err)
 
 	// access second one
 	iValue, err := mockPluginCfgReader.GetInt("number", 0)
 	expect.NoError(err)
 	expect.Equal(iValue, int64(1))
-	expect.True(mockPluginCfg.Validate())
+	err = mockPluginCfg.Validate()
+	expect.NoError(err)
 }
 
 // Function reads initializes pluginConfig with predefined values and

--- a/core/pluginconfigreader.go
+++ b/core/pluginconfigreader.go
@@ -46,20 +46,22 @@ type PluginConfigReader struct {
 
 // NewPluginConfigReader creates a new reader on top of a given config.
 func NewPluginConfigReader(config *PluginConfig) PluginConfigReader {
-	errorStack := tgo.NewErrorStack()
+	errors := tgo.NewErrorStack()
+	errors.SetFormat(tgo.ErrorStackFormatCSV)
 	return PluginConfigReader{
 		WithError: NewPluginConfigReaderWithError(config),
-		Errors:    &errorStack,
+		Errors:    &errors,
 	}
 }
 
 // NewPluginConfigReaderFromReader encapsulates a WithError reader that
 // is already attached to a config to read from.
 func NewPluginConfigReaderFromReader(reader PluginConfigReaderWithError) PluginConfigReader {
-	errorStack := tgo.NewErrorStack()
+	errors := tgo.NewErrorStack()
+	errors.SetFormat(tgo.ErrorStackFormatCSV)
 	return PluginConfigReader{
 		WithError: reader,
-		Errors:    &errorStack,
+		Errors:    &errors,
 	}
 }
 

--- a/core/pluginconfigreaderwitherror.go
+++ b/core/pluginconfigreaderwitherror.go
@@ -272,6 +272,7 @@ func (reader PluginConfigReaderWithError) GetModulatorArray(key string, logger l
 	}
 
 	errors := tgo.NewErrorStack()
+	errors.SetFormat(tgo.ErrorStackFormatCSV)
 
 	for _, plugin := range modPlugins {
 		if filter, isFilter := plugin.(Filter); isFilter {
@@ -308,6 +309,7 @@ func (reader PluginConfigReaderWithError) GetFilterArray(key string, logger logr
 	}
 
 	errors := tgo.NewErrorStack()
+	errors.SetFormat(tgo.ErrorStackFormatCSV)
 
 	for _, plugin := range modPlugins {
 		if filter, isFilter := plugin.(Filter); isFilter {
@@ -334,6 +336,7 @@ func (reader PluginConfigReaderWithError) GetFormatterArray(key string, logger l
 	}
 
 	errors := tgo.NewErrorStack()
+	errors.SetFormat(tgo.ErrorStackFormatCSV)
 
 	for _, plugin := range modPlugins {
 		if formatter, isFormatter := plugin.(Formatter); isFormatter {

--- a/core/pluginregistry.go
+++ b/core/pluginregistry.go
@@ -45,10 +45,12 @@ func (registry *pluginRegistry) Register(plugin Plugin, ID string) string {
 
 // RegisterUnique stores a plugin by its ID (a string) for later retrieval.
 // Name collisions are not resolved, duplicated names will not be registered.
-func (registry *pluginRegistry) RegisterUnique(plugin Plugin, ID string) {
+func (registry *pluginRegistry) RegisterUnique(plugin Plugin, ID string) bool {
 	if _, exists := registry.plugins[ID]; !exists {
 		registry.plugins[ID] = plugin
+		return true
 	}
+	return false
 }
 
 // GetPlugin returns a plugin by name or nil if not found.

--- a/testing/configs/test_aggregated_pipeline.conf
+++ b/testing/configs/test_aggregated_pipeline.conf
@@ -12,12 +12,13 @@ AggregatePipeline:
         consumerBar:
             Type: consumer.File
             File: /tmp/gollum_test_bar.log
-        router:
-            Type: router.Broadcast
-            Stream: files
         producer:
             Type: producer.File
             File: /tmp/gollum_test.log
             Batch:
                 TimeoutSec: 1
                 FlushCount: 1
+
+router:
+    Type: router.Broadcast
+    Stream: files


### PR DESCRIPTION
Fix for #151, #172, fixing parts of #154
Configuration error handling and logging was broken in several ways.
The following fixes are included:

- config.Validate is now called again during startup (related to #154)
- "Streams" is now mandatory for consumers and producers
- "Stream" is now mandatory for routers
- fixed missing log messages during shutdown due to a missing purge
- fixed coloring of log messages during startup due to setting the formatter to late
- having no consumer/producers leads to shutdown
- proper use of logrus.WithError wthin main package