### PR TITLE
#195: race condition fix

### DIFF
--- a/core/plugin.go
+++ b/core/plugin.go
@@ -171,8 +171,9 @@ func NewPluginWithConfig(config PluginConfig) (Plugin, error) {
 		return nil, err
 	}
 
-	// Note: The current YAML format does actually prevent this, but left here
-	//       as a precaution.
+	// Note: The current YAML format does actually prevent this, but fallback
+	//       streams are being created during runtime. Those should be unique
+	//       but we might still run into bugs here.
 	if len(config.ID) > 0 && !PluginRegistry.RegisterUnique(plugin, config.ID) {
 		return nil, fmt.Errorf("Plugin id '%s' must be unique", config.ID)
 	}

--- a/core/pluginregistry_test.go
+++ b/core/pluginregistry_test.go
@@ -27,10 +27,6 @@ func TestPluginRegistry(t *testing.T) {
 	expect.NotNil(err)
 	expect.Equal(registered, len(PluginRegistry.plugins))
 
-	// Test for Register
-	PluginRegistry.Register(plugin, "aPlugin")
-	expect.Equal(registered+1, len(PluginRegistry.plugins))
-
 	// Test for RegisterUnique
 	PluginRegistry.RegisterUnique(plugin, "aPlugin")
 	expect.Equal(registered+1, len(PluginRegistry.plugins))

--- a/core/streamregistry_test.go
+++ b/core/streamregistry_test.go
@@ -24,8 +24,8 @@ func getMockStreamRegistry() streamRegistry {
 	return streamRegistry{
 		routers:     map[MessageStreamID]Router{},
 		name:        map[MessageStreamID]string{},
-		streamGuard: new(sync.Mutex),
-		nameGuard:   new(sync.Mutex),
+		streamGuard: new(sync.RWMutex),
+		nameGuard:   new(sync.RWMutex),
 		wildcard:    []Producer{},
 	}
 }


### PR DESCRIPTION
Some parts of the code neglected the fact that plugins are added during runtime.
The stream- and plugin-registry now use RWMutexes (as they act like caches) for improved read performance.