### PR TITLE
Make metadata an on-demand field

### DIFF
--- a/contrib/native/kafka/kafkaproducer.go
+++ b/contrib/native/kafka/kafkaproducer.go
@@ -346,11 +346,13 @@ func (prod *KafkaProducer) produceMessage(msg *core.Message) {
 		prod.Logger.Error(err)
 	}
 
-	metadata := msg.GetMetadata()
 	kafkaMsg := &messageWrapper{
-		key:   metadata.GetValue(prod.keyField),
 		value: msg.GetPayload(),
 		user:  serializedOriginal,
+	}
+	
+	if metadata := msg.TryGetMetadata(); metadata != nil {
+		kafkaMsg.key = metadata.GetValue(prod.keyField),
 	}
 
 	if err := topic.handle.Produce(kafkaMsg); err != nil {

--- a/contrib/native/kafka/kafkaproducer.go
+++ b/contrib/native/kafka/kafkaproducer.go
@@ -350,9 +350,9 @@ func (prod *KafkaProducer) produceMessage(msg *core.Message) {
 		value: msg.GetPayload(),
 		user:  serializedOriginal,
 	}
-	
+
 	if metadata := msg.TryGetMetadata(); metadata != nil {
-		kafkaMsg.key = metadata.GetValue(prod.keyField),
+		kafkaMsg.key = metadata.GetValue(prod.keyField)
 	}
 
 	if err := topic.handle.Produce(kafkaMsg); err != nil {

--- a/core/message.go
+++ b/core/message.go
@@ -57,9 +57,7 @@ func NewMessage(source MessageSource, data []byte, metadata Metadata, streamID M
 
 	message.data.payload = buffer
 	message.data.streamID = streamID
-	if metadata == nil {
-		message.data.Metadata = make(Metadata)
-	} else {
+	if metadata != nil && len(metadata) > 0 {
 		message.data.Metadata = metadata
 	}
 
@@ -125,8 +123,18 @@ func (msg *Message) GetPayload() []byte {
 	return msg.data.payload
 }
 
-// GetMetadata returns the current Metadata
+// GetMetadata returns the current Metadata. If no metadata is present, the
+// metadata map will be created by this call.
 func (msg *Message) GetMetadata() Metadata {
+	if msg.data.Metadata == nil {
+		msg.data.Metadata = make(Metadata)
+	}
+	return msg.data.Metadata
+}
+
+// TryGetMetadata returns the current Metadata. If no metadata is present, nil
+// will be returned.
+func (msg *Message) TryGetMetadata() Metadata {
 	return msg.data.Metadata
 }
 
@@ -194,7 +202,12 @@ func (msg *Message) CloneOriginal() *Message {
 func (msg *Message) FreezeOriginal() {
 	msg.orig.payload = getPayloadCopy(msg.data.payload)
 	msg.orig.streamID = msg.data.streamID
-	msg.orig.Metadata = msg.data.Metadata.Clone()
+
+	if msg.data.Metadata == nil {
+		msg.orig.Metadata = nil
+	} else {
+		msg.orig.Metadata = msg.data.Metadata.Clone()
+	}
 }
 
 // Serialize generates a new payload containing all data that can be preserved

--- a/producer/kafka.go
+++ b/producer/kafka.go
@@ -517,7 +517,9 @@ func (prod *Kafka) produceMessage(msg *core.Message) {
 
 func (prod *Kafka) getKafkaMsgKey(msg *core.Message) []byte {
 	if len(prod.keyField) > 0 {
-		return msg.GetMetadata().GetValue(prod.keyField)
+		if metadata := msg.TryGetMetadata(); metadata != nil {
+			return metadata.GetValue(prod.keyField)
+		}
 	}
 
 	return []byte{}


### PR DESCRIPTION
Profiling showed that adding metadata to a message comes with some overhead.
As it is not needed in many cases, this PR makes it optional.

- Passing metadata to NewMessage will of course use that map directly (unless it is empty)
- GetMetadata creates the map if not existing
- TryGetMetadata returns nil (for read only access)
- FreezeOriginal will take into account that metadata can be nil
- Serialize and Deserialize already supported nil values