### PR TITLE
Add SkipIfEmpty option to all formatters

### DIFF
--- a/core/formatter.go
+++ b/core/formatter.go
@@ -18,17 +18,24 @@ package core
 // A Formatter also have to implement the modulator interface
 type Formatter interface {
 	ApplyFormatter(msg *Message) error
+	CanBeApplied(msg *Message) bool
 }
 
 // FormatterArray is a type wrapper to []Formatter to make array of formatter
 type FormatterArray []Formatter
 
+// CanBeApplied returns true if the array is not empty
+func (formatters FormatterArray) CanBeApplied(msg *Message) bool {
+	return len(formatters) > 0
+}
+
 // ApplyFormatter calls ApplyFormatter on every formatter
 func (formatters FormatterArray) ApplyFormatter(msg *Message) error {
 	for _, formatter := range formatters {
-		err := formatter.ApplyFormatter(msg)
-		if err != nil {
-			return err
+		if formatter.CanBeApplied(msg) {
+			if err := formatter.ApplyFormatter(msg); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/core/formatter_test.go
+++ b/core/formatter_test.go
@@ -69,9 +69,25 @@ func TestFormatterModulatorApplyFormatter(t *testing.T) {
 
 	msg := NewMessage(nil, []byte("test"), nil, InvalidStreamID)
 
-	expect.Nil(formatterModulator.ApplyFormatter(msg))
+	expect.NoError(formatterModulator.ApplyFormatter(msg))
 	expect.True(formatter.ConfigureHasCalled)
 	expect.True(formatter.ApplyFormatterHasCalled)
+}
+
+func TestFormatterModulatorApplyFormatterSkipIfEmpty(t *testing.T) {
+	expect := ttesting.NewExpect(t)
+
+	formatter, err := getDummyFormatter()
+	formatter.SkipIfEmpty = true
+	expect.NoError(err)
+
+	formatterModulator := NewFormatterModulator(formatter)
+
+	msg := NewMessage(nil, []byte(""), nil, InvalidStreamID)
+
+	expect.NoError(formatterModulator.ApplyFormatter(msg))
+	expect.True(formatter.ConfigureHasCalled)
+	expect.False(formatter.ApplyFormatterHasCalled)
 }
 
 func TestFormatterModulatorModulate(t *testing.T) {

--- a/core/formattermodulator.go
+++ b/core/formattermodulator.go
@@ -41,7 +41,15 @@ func (formatterModulator *FormatterModulator) Modulate(msg *Message) ModulateRes
 	return ModulateResultContinue
 }
 
+// CanBeApplied returns true if the array is not empty
+func (formatterModulator *FormatterModulator) CanBeApplied(msg *Message) bool {
+	return formatterModulator.Formatter.CanBeApplied(msg)
+}
+
 // ApplyFormatter calls the Formatter.ApplyFormatter method
 func (formatterModulator *FormatterModulator) ApplyFormatter(msg *Message) error {
-	return formatterModulator.Formatter.ApplyFormatter(msg)
+	if formatterModulator.CanBeApplied(msg) {
+		return formatterModulator.Formatter.ApplyFormatter(msg)
+	}
+	return nil
 }

--- a/core/messagehelper.go
+++ b/core/messagehelper.go
@@ -11,7 +11,11 @@ type SetAppliedContent func(msg *Message, content []byte)
 func GetAppliedContentGetFunction(applyTo string) GetAppliedContent {
 	if applyTo != "" {
 		return func(msg *Message) []byte {
-			return msg.GetMetadata().GetValue(applyTo)
+			metadata := msg.TryGetMetadata()
+			if metadata == nil {
+				return []byte{}
+			}
+			return metadata.GetValue(applyTo)
 		}
 	}
 

--- a/core/metadata.go
+++ b/core/metadata.go
@@ -22,7 +22,17 @@ func (meta Metadata) SetValue(key string, value []byte) {
 	meta[key] = value
 }
 
-// GetValue returns a meta data value by key
+// TrySetValue sets a key value pair only if the key is already existing
+func (meta Metadata) TrySetValue(key string, value []byte) bool {
+	if _, exists := meta[key]; exists {
+		meta[key] = value
+		return true
+	}
+	return false
+}
+
+// GetValue returns a meta data value by key. This function returns a value if
+// key is not set, too. In that case it will return an empty byte array.
 func (meta Metadata) GetValue(key string) []byte {
 	if value, isSet := meta[key]; isSet {
 		return value
@@ -31,23 +41,32 @@ func (meta Metadata) GetValue(key string) []byte {
 	return []byte{}
 }
 
-// GetValueString returns the meta value by GetValue as string
+// TryGetValue behaves like GetValue but returns a second value which denotes
+// if the key was set or not.
+func (meta Metadata) TryGetValue(key string) ([]byte, bool) {
+	if value, isSet := meta[key]; isSet {
+		return value, true
+	}
+	return []byte{}, false
+}
+
+// GetValueString casts the results of GetValue to a string
 func (meta Metadata) GetValueString(key string) string {
 	return string(meta.GetValue(key))
 }
 
-// Delete delete a meta data value by key
+// TryGetValueString casts the data result of TryGetValue to string
+func (meta Metadata) TryGetValueString(key string) (string, bool) {
+	data, exists := meta.TryGetValue(key)
+	return string(data), exists
+}
+
+// Delete removes the given key from the map
 func (meta Metadata) Delete(key string) {
 	delete(meta, key)
 }
 
-// HasValue returns true if the given key exists
-func (meta Metadata) HasValue(key string) bool {
-	_, exists := meta[key]
-	return exists
-}
-
-// Clone Metadata byte values to new Metadata map
+// Clone creates an exact copy of this metadata map.
 func (meta Metadata) Clone() (clone Metadata) {
 	clone = Metadata{}
 	for k, v := range meta {
@@ -55,6 +74,5 @@ func (meta Metadata) Clone() (clone Metadata) {
 		copy(vCopy, v)
 		clone[k] = vCopy
 	}
-
 	return
 }

--- a/core/metadata.go
+++ b/core/metadata.go
@@ -41,6 +41,12 @@ func (meta Metadata) Delete(key string) {
 	delete(meta, key)
 }
 
+// HasValue returns true if the given key exists
+func (meta Metadata) HasValue(key string) bool {
+	_, exists := meta[key]
+	return exists
+}
+
 // Clone Metadata byte values to new Metadata map
 func (meta Metadata) Clone() (clone Metadata) {
 	clone = Metadata{}

--- a/core/metadata_test.go
+++ b/core/metadata_test.go
@@ -1,0 +1,60 @@
+// Copyright 2015-2017 trivago GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"github.com/trivago/tgo/ttesting"
+	"testing"
+)
+
+func TestMetadataSetGet(t *testing.T) {
+	expect := ttesting.NewExpect(t)
+
+	meta := make(Metadata)
+
+	meta.SetValue("foo", []byte("foo_value"))
+	expect.Equal([]byte("foo_value"), meta.GetValue("foo"))
+
+	setExisiting := meta.TrySetValue("foo", []byte("foo_value"))
+	expect.True(setExisiting)
+
+	setExisiting = meta.TrySetValue("bar", []byte("bar_value"))
+	expect.False(setExisiting)
+
+	barValue, exists := meta.TryGetValue("bar")
+	expect.False(exists)
+	expect.Equal([]byte{}, barValue)
+
+	barStrValue, exists := meta.TryGetValueString("bar")
+	expect.False(exists)
+	expect.Equal("", barStrValue)
+
+	fooVal, exists := meta.TryGetValue("foo")
+	expect.True(exists)
+	expect.Equal([]byte("foo_value"), fooVal)
+
+	fooStrVal, exists := meta.TryGetValueString("foo")
+	expect.True(exists)
+	expect.Equal("foo_value", fooStrVal)
+
+	meta2 := meta.Clone()
+
+	meta.Delete("foo")
+	_, exists = meta.TryGetValue("foo")
+	expect.False(exists)
+
+	_, exists = meta2.TryGetValue("foo")
+	expect.True(exists)
+}

--- a/core/simpleformatter.go
+++ b/core/simpleformatter.go
@@ -30,10 +30,14 @@ import (
 // specify the name of a metadata field to target.
 // By default this parameter is set to "".
 //
+// - SkipIfEmpty: When set to true, this formatter will not be applied to data
+// that is empty or - in case of metadata - not existing.
+// By default this parameter is set to false
 type SimpleFormatter struct {
 	Logger            logrus.FieldLogger
 	GetAppliedContent GetAppliedContent
 	SetAppliedContent SetAppliedContent
+	SkipIfEmpty       bool `config:"SkipIfEmpty"`
 }
 
 // Configure sets up all values required by SimpleFormatter.
@@ -43,6 +47,14 @@ func (format *SimpleFormatter) Configure(conf PluginConfigReader) {
 	applyTo := conf.GetString("ApplyTo", "")
 	format.GetAppliedContent = GetAppliedContentGetFunction(applyTo)
 	format.SetAppliedContent = GetAppliedContentSetFunction(applyTo)
+}
+
+// CanBeApplied returns true if the formatter can be applied to this message
+func (format *SimpleFormatter) CanBeApplied(msg *Message) bool {
+	if format.SkipIfEmpty {
+		return len(format.GetAppliedContent(msg)) > 0
+	}
+	return true
 }
 
 // SetLogger sets the scoped logger to be used for this formatter

--- a/docs/src/gen/formatter/base64decode.rst
+++ b/docs/src/gen/formatter/base64decode.rst
@@ -33,6 +33,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/base64encode.rst
+++ b/docs/src/gen/formatter/base64encode.rst
@@ -32,6 +32,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/clear.rst
+++ b/docs/src/gen/formatter/clear.rst
@@ -20,6 +20,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/collectdtoinflux08.rst
+++ b/docs/src/gen/formatter/collectdtoinflux08.rst
@@ -21,6 +21,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/collectdtoinflux09.rst
+++ b/docs/src/gen/formatter/collectdtoinflux09.rst
@@ -21,6 +21,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/collectdtoinflux10.rst
+++ b/docs/src/gen/formatter/collectdtoinflux10.rst
@@ -21,6 +21,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/double.rst
+++ b/docs/src/gen/formatter/double.rst
@@ -61,6 +61,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/envelope.rst
+++ b/docs/src/gen/formatter/envelope.rst
@@ -39,6 +39,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/extractjson.rst
+++ b/docs/src/gen/formatter/extractjson.rst
@@ -50,6 +50,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/groktojson.rst
+++ b/docs/src/gen/formatter/groktojson.rst
@@ -35,6 +35,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/hostname.rst
+++ b/docs/src/gen/formatter/hostname.rst
@@ -31,6 +31,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/identifier.rst
+++ b/docs/src/gen/formatter/identifier.rst
@@ -59,6 +59,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/jsontoarray.rst
+++ b/docs/src/gen/formatter/jsontoarray.rst
@@ -41,6 +41,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/jsontoinflux10.rst
+++ b/docs/src/gen/formatter/jsontoinflux10.rst
@@ -75,6 +75,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/metadatacopy.rst
+++ b/docs/src/gen/formatter/metadatacopy.rst
@@ -31,6 +31,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/processjson.rst
+++ b/docs/src/gen/formatter/processjson.rst
@@ -232,6 +232,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/processtsv.rst
+++ b/docs/src/gen/formatter/processtsv.rst
@@ -165,6 +165,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/regexp.rst
+++ b/docs/src/gen/formatter/regexp.rst
@@ -48,6 +48,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/runlength.rst
+++ b/docs/src/gen/formatter/runlength.rst
@@ -39,6 +39,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/sequence.rst
+++ b/docs/src/gen/formatter/sequence.rst
@@ -33,6 +33,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/serialize.rst
+++ b/docs/src/gen/formatter/serialize.rst
@@ -21,6 +21,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/splitpick.rst
+++ b/docs/src/gen/formatter/splitpick.rst
@@ -39,6 +39,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/splittojson.rst
+++ b/docs/src/gen/formatter/splittojson.rst
@@ -47,6 +47,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/streamname.rst
+++ b/docs/src/gen/formatter/streamname.rst
@@ -37,6 +37,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/streamrevert.rst
+++ b/docs/src/gen/formatter/streamrevert.rst
@@ -21,6 +21,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/streamroute.rst
+++ b/docs/src/gen/formatter/streamroute.rst
@@ -41,6 +41,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/templatejson.rst
+++ b/docs/src/gen/formatter/templatejson.rst
@@ -35,6 +35,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/texttojson.rst
+++ b/docs/src/gen/formatter/texttojson.rst
@@ -211,6 +211,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/timestamp.rst
+++ b/docs/src/gen/formatter/timestamp.rst
@@ -33,6 +33,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 

--- a/docs/src/gen/formatter/trim.rst
+++ b/docs/src/gen/formatter/trim.rst
@@ -55,6 +55,14 @@ Parameters (from core.SimpleFormatter)
   
   
 
+**SkipIfEmpty**
+
+  When set to true, this formatter will not be applied to data
+  that is empty or - in case of metadata - not existing.
+  By default this parameter is set to false
+  
+  
+
 Examples
 --------
 


### PR DESCRIPTION
## What is the purpose of this pull request

This PR adds an option to all formatters allowing to skip empty payload.
Empty in this case means an empty byte array as well as a non existing metadata field
This is a useful switch when dealing with data that only should be formatted if valid, e.g. data from a kafka topic where some messages have a key set and some haven't.

## Config to verify:

<!--- Provide a config to verify/test this pull request -->

```yaml
In:
    Type: consumer.Console
    Streams: data
    Modulators:
        - format.Timestamp:
            SkipIfEmpty: true
        - format.Envelope

Out:
    Type: producer.Console
    Streams: data
```


## Checklist
<!--
Mark everything that applies:
-->

- [x] `make test` executed successfully
- [x] unit test provided
- [ ] integration test provided
- [x] docs updated
