### PR TITLE
Remove sub-formatters from MetadataCopy

### DIFF
--- a/docs/src/gen/formatter/metadatacopy.rst
+++ b/docs/src/gen/formatter/metadatacopy.rst
@@ -12,10 +12,11 @@ payload or from other metadata fields.
 Parameters
 ----------
 
-**WriteTo**
+**CopyToKeys**
 
-  A named list of meta data keys. Each entry can contain further modulators
-  to change or filter the message content before setting the meta data value.
+  A list of meta data keys to copy the payload or metadata
+  content to.
+  By default this parameter is set to an empty list.
   
   
 
@@ -42,7 +43,9 @@ Parameters (from core.SimpleFormatter)
 Examples
 --------
 
-This example sets the meta fields `hostname`, `base64Value` and `payloadCopy` of each message:
+This example copies the payload to the fields prefix and key. The prefix
+field will extract everything up to the first space as hostname, the key
+field will contain a hash over the complete payload.
 
 .. code-block:: yaml
 
@@ -51,12 +54,14 @@ This example sets the meta fields `hostname`, `base64Value` and `payloadCopy` of
 	   Streams: "*"
 	   Modulators:
 	     - format.MetadataCopy:
-	       WriteTo:
-	         hostname:               # meta data key
-	           - format.Hostname     # further modulators
-	         base64Value:
-	           - format.Base64Encode
-	         payloadCopy: []         # 1:1 copy without modulators
+	       CopyToKeys: ["prefix", "key"]
+	     - format.SplitPick:
+	       ApplyTo: prefix
+	       Delimiter: " "
+	       Index: 0
+	     - formatter.Identifier
+	       Generator: hash
+	       ApplyTo: key
 
 
 

--- a/docs/src/gen/formatter/runlength.rst
+++ b/docs/src/gen/formatter/runlength.rst
@@ -21,9 +21,11 @@ Parameters
 
 **StoreRunlengthOnly** (default: false)
 
-  If this value is set to "true" the runlength only will stored.
-  This option is useful to store the runlength only in a meta data field by the `ApplyTo` parameter.
-  By default this parameter is set to "false".
+  If this value is set to "true" only the runlength will
+  stored. This option is useful to e.g. create metadata fields only containing
+  the length of the payload. When set to "true" the Separator parameter will
+  be ignored.
+  By default this parameter is set to false.
   
   
 
@@ -50,9 +52,8 @@ Parameters (from core.SimpleFormatter)
 Examples
 --------
 
-In this example is the `format.Runlength` used as "subformatter" from the `format.MetadataCopy`.
-The `format.MetadataCopy` formatter copies the payload to the defined meta data field.
-At the end the `format.Runlength` formatter will transform the meta data value to the length.
+This example will store the length of the payload in a separate metadata
+field.
 
 .. code-block:: yaml
 
@@ -61,12 +62,11 @@ At the end the `format.Runlength` formatter will transform the meta data value t
 	   Streams: "*"
 	   Modulators:
 	     - format.MetadataCopy:
-	         WriteTo:
-	           - original_length:
-	             - format.Runlength:
-	                 Separator: ""
+	       CopyToKeys: ["length"]
+	     - format.Runlength:
+	       ApplyTo: length
+	       StoreRunlengthOnly: true
 
-	                StoreRunlengthOnly: true
 
 
 

--- a/format/metadatacopy.go
+++ b/format/metadatacopy.go
@@ -16,10 +16,7 @@ package format
 
 import (
 	"github.com/trivago/gollum/core"
-	"github.com/trivago/tgo/tcontainer"
 )
-
-type metaDataMap map[string]core.ModulatorArray
 
 // MetadataCopy formatter plugin
 //
@@ -28,28 +25,33 @@ type metaDataMap map[string]core.ModulatorArray
 //
 // Parameters
 //
-// - WriteTo: A named list of meta data keys. Each entry can contain further modulators
-// to change or filter the message content before setting the meta data value.
+// - CopyToKeys: A list of meta data keys to copy the payload or metadata
+// content to.
+// By default this parameter is set to an empty list.
 //
 // Examples
 //
-// This example sets the meta fields `hostname`, `base64Value` and `payloadCopy` of each message:
+// This example copies the payload to the fields prefix and key. The prefix
+// field will extract everything up to the first space as hostname, the key
+// field will contain a hash over the complete payload.
 //
 //  exampleConsumer:
 //    Type: consumer.Console
 //    Streams: "*"
 //    Modulators:
 //      - format.MetadataCopy:
-//        WriteTo:
-//          hostname:               # meta data key
-//            - format.Hostname     # further modulators
-//          base64Value:
-//            - format.Base64Encode
-//          payloadCopy: []         # 1:1 copy without modulators
+//        CopyToKeys: ["prefix", "key"]
+//      - format.SplitPick:
+//        ApplyTo: prefix
+//        Delimiter: " "
+//        Index: 0
+//      - formatter.Identifier
+//        Generator: hash
+//        ApplyTo: key
 //
 type MetadataCopy struct {
 	core.SimpleFormatter `gollumdoc:"embed_type"`
-	metaData             metaDataMap
+	metaDataKeys         []string `config:"CopyToKeys"`
 }
 
 func init() {
@@ -58,48 +60,14 @@ func init() {
 
 // Configure initializes this formatter with values from a plugin config.
 func (format *MetadataCopy) Configure(conf core.PluginConfigReader) {
-	format.metaData = format.newMetaDataMap(conf.GetMap("WriteTo", tcontainer.MarshalMap{}))
 }
 
 // ApplyFormatter update message payload
 func (format *MetadataCopy) ApplyFormatter(msg *core.Message) error {
-	for metaDataKey, modulators := range format.metaData {
-		msg.GetMetadata().SetValue(metaDataKey, format.modulateMetadataValue(msg, modulators))
+	meta := msg.GetMetadata()
+	data := format.GetAppliedContent(msg)
+	for _, key := range format.metaDataKeys {
+		meta.SetValue(key, data)
 	}
-
 	return nil
-}
-
-// modulateMetadataValue returns the final meta value
-func (format *MetadataCopy) modulateMetadataValue(msg *core.Message, modulators core.ModulatorArray) []byte {
-	modulationMsg := core.NewMessage(nil, format.GetAppliedContent(msg), nil, core.InvalidStreamID)
-
-	modulateResult := modulators.Modulate(modulationMsg)
-	if modulateResult == core.ModulateResultContinue {
-		return modulationMsg.GetPayload()
-	}
-
-	return []byte{}
-}
-
-func (format *MetadataCopy) newMetaDataMap(metaData tcontainer.MarshalMap) metaDataMap {
-	result := metaDataMap{}
-	writeToConfig := core.NewPluginConfig("", "format.MetadataCopy.WriteTo")
-	reader := core.NewPluginConfigReaderWithError(&writeToConfig)
-
-	for keyMetadata, metaDataValue := range metaData {
-		tempMap := tcontainer.NewMarshalMap()
-		tempMap[keyMetadata] = metaDataValue
-
-		writeToConfig.Read(tempMap)
-		modulator, err := reader.GetModulatorArray(keyMetadata, format.Logger, core.ModulatorArray{})
-		if err != nil {
-			format.Logger.Error("Can't get mmodulators. Error message: ", err)
-			break
-		}
-
-		result[keyMetadata] = modulator
-	}
-
-	return result
 }

--- a/format/runlength.go
+++ b/format/runlength.go
@@ -29,26 +29,26 @@ import (
 // - Separator: This value is used as separator.
 // By default this parameter is set to ":".
 //
-// - StoreRunlengthOnly: If this value is set to "true" the runlength only will stored.
-// This option is useful to store the runlength only in a meta data field by the `ApplyTo` parameter.
-// By default this parameter is set to "false".
+// - StoreRunlengthOnly: If this value is set to "true" only the runlength will
+// stored. This option is useful to e.g. create metadata fields only containing
+// the length of the payload. When set to "true" the Separator parameter will
+// be ignored.
+// By default this parameter is set to false.
 //
 // Examples
 //
-// In this example is the `format.Runlength` used as "subformatter" from the `format.MetadataCopy`.
-// The `format.MetadataCopy` formatter copies the payload to the defined meta data field.
-// At the end the `format.Runlength` formatter will transform the meta data value to the length.
+// This example will store the length of the payload in a separate metadata
+// field.
 //
 //  exampleConsumer:
 //    Type: consumer.Console
 //    Streams: "*"
 //    Modulators:
 //      - format.MetadataCopy:
-//          WriteTo:
-//            - original_length:
-//              - format.Runlength:
-//                  Separator: ""
-// 	                StoreRunlengthOnly: true
+//        CopyToKeys: ["length"]
+//      - format.Runlength:
+//        ApplyTo: length
+//        StoreRunlengthOnly: true
 //
 type Runlength struct {
 	core.SimpleFormatter `gollumdoc:"embed_type"`


### PR DESCRIPTION
## The purpose of this pull request

This change removes the sub formatters from metadata copy.
- It will simplify the formatter a lot
- There already is a possibility to change the created metadata fields later on
- The nested structure is bad to read and is counter intuitive because of non-processed fields
- It is somewhat duplicate code as the modulators have to be prepared
- It has additional runtime costs over the "top-level modulator" approach

## Checklist

- [x] `make test` executed successfully
- [x] unit test provided
- [x] docs updated
