### PR TITLE
fixed rotation issue if more than one stream write to the same target file

### DIFF
--- a/producer/file/targetFile.go
+++ b/producer/file/targetFile.go
@@ -112,3 +112,7 @@ func (streamFile *TargetFile) GetDir() (string, error) {
 func (streamFile *TargetFile) GetSymlinkPath() string {
 	return fmt.Sprintf("%s/%s_current%s", streamFile.dir, streamFile.name, streamFile.ext)
 }
+
+func (streamFile *TargetFile) String() string {
+	return streamFile.GetOriginalPath()
+}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

## The purpose of this pull request

- fixed rotation issue if more than one stream write to the same target file 


## Config to verify

```yaml
StdIn:
    Type: consumer.Console
    Streams: 
      - foo
      - bar

GollumOut:
  Type: producer.File
  Streams:
    - foo
    - bar
  File: /tmp/gollum.log
  Rotation:
    Enable: true
    SizeMB: 512
  Prune:
    Count: 7
```

## Checklist
<!--
Mark everything that applies:
-->

- [x] `make test` executed successfully
- [ ] unit test provided
- [ ] integration test provided
