### PR TITLE
Bugfix/fix testconfig exit code

### DIFF
--- a/format/texttojson.go
+++ b/format/texttojson.go
@@ -132,7 +132,7 @@ const (
 //    Type: consumer.Console
 //    Streams: console
 //    Modulators:
-//      - format.JSON:
+//      - format.TextToJSON:
 //        Directives:
 //          - "findKey   :\":  key       :      :        "
 //          - "findKey   :}:             : pop  : end    "

--- a/main.go
+++ b/main.go
@@ -77,9 +77,26 @@ func mainWithExitCode() int {
 	logrus.Debug("GOLLUM STARTING")
 	defer logrus.Debug("GOLLUM STOPPED")
 
-	config := readConfig()
+	configFile := *flagConfigFile
+	if *flagTestConfigFile != "" {
+		configFile = *flagTestConfigFile
+	}
+
+	config := readConfig(configFile)
 	if config == nil {
 		return tos.ExitError // ### exit, config failed to parse ###
+	}
+
+	if *flagTestConfigFile != "" {
+		logrus.SetLevel(logrus.WarnLevel)
+		fmt.Println("Testing config", configFile)
+
+		if !testConfig(config) {
+			return tos.ExitError // ### exit, config test failed ###
+		}
+
+		fmt.Println("Config OK.")
+		return tos.ExitSuccess // ### exit, config test successfully ###
 	}
 
 	configureRuntime()
@@ -117,6 +134,19 @@ func mainWithExitCode() int {
 	return tos.ExitSuccess
 }
 
+// testConfig test and validate config object
+func testConfig(config *core.Config) bool {
+	coordinator := NewCoordinator()
+	defer coordinator.Shutdown()
+
+	if err := coordinator.Configure(config); err != nil {
+		logrus.WithError(err).Error("Configure pass failed.")
+		return false
+	}
+
+	return true
+}
+
 // initLogrus initializes the logging framework
 func initLogrus() func() {
 	// Initialize logger.LogrusHookBuffer
@@ -149,23 +179,10 @@ func initLogrus() func() {
 }
 
 // readConfig reads and checks the config file for errors.
-func readConfig() *core.Config {
-	configFile := *flagConfigFile
-	testAndExit := false
-
-	if *flagTestConfigFile != "" {
-		configFile = *flagTestConfigFile
-		testAndExit = true
-	}
-
+func readConfig(configFile string) *core.Config {
 	if *flagHelp || configFile == "" {
 		logrus.Error("Please provide a config file")
 		return nil
-	}
-
-	if testAndExit {
-		logrus.SetLevel(logrus.WarnLevel)
-		fmt.Println("Testing config", configFile)
 	}
 
 	config, err := core.ReadConfigFromFile(configFile)
@@ -176,17 +193,6 @@ func readConfig() *core.Config {
 
 	if err := config.Validate(); err != nil {
 		logrus.WithError(err).Error("Config validation failed")
-		return nil
-	}
-
-	if testAndExit {
-		coordinator := NewCoordinator()
-		if err := coordinator.Configure(config); err != nil {
-			logrus.WithError(err).Error("Configure pass failed.")
-		} else {
-			fmt.Println("Config OK.")
-		}
-		coordinator.Shutdown()
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -77,17 +77,13 @@ func mainWithExitCode() int {
 	logrus.Debug("GOLLUM STARTING")
 	defer logrus.Debug("GOLLUM STOPPED")
 
-	configFile := *flagConfigFile
-	if *flagTestConfigFile != "" {
-		configFile = *flagTestConfigFile
-	}
-
+	configFile, testConfigAndExit := getConfigFile()
 	config := readConfig(configFile)
 	if config == nil {
 		return tos.ExitError // ### exit, config failed to parse ###
 	}
 
-	if *flagTestConfigFile != "" {
+	if testConfigAndExit {
 		logrus.SetLevel(logrus.WarnLevel)
 		fmt.Println("Testing config", configFile)
 
@@ -132,6 +128,13 @@ func mainWithExitCode() int {
 	coordinator.StartPlugins()
 	coordinator.Run()
 	return tos.ExitSuccess
+}
+
+func getConfigFile() (configFile string, justTest bool) {
+	if *flagTestConfigFile != "" {
+		return *flagTestConfigFile, true
+	}
+	return *flagConfigFile, false
 }
 
 // testConfig test and validate config object


### PR DESCRIPTION
## The purpose of this pull request

- fixed exit code for successfully config tests
- fixed doc example

## Steps to verify

```sh
gollum -tc config/socket_receive.conf && echo $?
```

## Checklist

- [x] `make test` executed successfully
- [ ] docs updated
