### PR TITLE
Syslog metadata support

### DIFF
--- a/consumer/syslogd.go
+++ b/consumer/syslogd.go
@@ -15,14 +15,15 @@
 package consumer
 
 import (
-	"github.com/trivago/gollum/core"
-	"github.com/trivago/tgo/tnet"
-	"gopkg.in/mcuadros/go-syslog.v2"
-	"gopkg.in/mcuadros/go-syslog.v2/format"
 	"os"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/trivago/gollum/core"
+	"github.com/trivago/tgo/tnet"
+	syslog "gopkg.in/mcuadros/go-syslog.v2"
+	"gopkg.in/mcuadros/go-syslog.v2/format"
 )
 
 // Syslogd consumer plugin
@@ -53,6 +54,9 @@ import (
 //
 // - SetMetadata: When set to true, syslog based metadata will be attached to
 // the message. The metadata fields added depend on the protocol version used.
+// RFC3164 supports: tag, timestamp, hostname, priority, facility, severity.
+// RFC5424 and RFC6587 support: app_name, version, proc_id , msg_id, timestamp,
+// hostname, priority, facility, severity.
 // By default this parameter is set to "false".
 //
 // - TimestampFormat: When using SetMetadata this string denotes the go time

--- a/consumer/syslogd.go
+++ b/consumer/syslogd.go
@@ -209,14 +209,14 @@ func (cons *Syslogd) Consume(workers *sync.WaitGroup) {
 	case "unix":
 		if err := server.ListenUnixgram(cons.address); err != nil {
 			if errRemove := os.Remove(cons.address); errRemove != nil {
+				cons.Logger.WithError(errRemove).Error("Failed to remove exisiting socket")
+			} else {
 				cons.Logger.Warning("Found existing socket ", cons.address, ". Removing.")
 				err = server.ListenUnixgram(cons.address)
-			} else {
-				cons.Logger.Error("Failed to remove exisiting socket: ", errRemove)
 			}
 
 			if err != nil {
-				cons.Logger.Error("Failed to open unix://", cons.address, ":", err)
+				cons.Logger.WithError(err).Error("Failed to open unix://", cons.address)
 			}
 		}
 	case "udp":


### PR DESCRIPTION
## The purpose of this pull request

This PR adds metadata support to the syslog consumer.
Also fixes a bug where the consumer would not try to remove an existing UDS file like consumer.Socket does.

## Config to verify

<!--- Provide a config to verify/test this pull request -->

```yaml
SyslogIn:
  Type: consumer.Syslogd
  Address: "udp://0.0.0.0:5150"
  Format: "RFC3164"
  SetMetadata: true
  Streams: "syslog"

RouteByFacility:
  Type: router.Metadata
  Stream: "syslog"
  Key: "facility"

Console:
  Type: producer.Console
  Streams: "*"
  Modulators:
    - format.StreamName
    - format.Envelope
```

## Checklist
<!--
Mark everything that applies:
-->

- [x] `make test` executed successfully
- [x] docs updated
