### PR TITLE
extend format.MetadataCopy to allow more precise copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Gollum changelog
 
+## 0.5.1
+
+This is a patch / minor features release.
+
+### New with 0.5.1
+
+ * format.MetadataCopy has been updated to support free copying between metadata and payload
+
+### Fixed with 0.5.1
+
+ * fixed inversion of -lc always
+
 ## 0.5.0
 
 Gollum 0.5.0 contains major breaking changes in all areas.

--- a/core/version.go
+++ b/core/version.go
@@ -21,7 +21,7 @@ import (
 const (
 	gollumMajorVer = 0
 	gollumMinorVer = 5
-	gollumPatchVer = 0
+	gollumPatchVer = 1
 	gollumDevVer   = 0
 )
 

--- a/docs/src/gen/consumer/syslogd.rst
+++ b/docs/src/gen/consumer/syslogd.rst
@@ -22,7 +22,7 @@ Parameters
   Defines the IP address or UNIX socket to listen to.
   This can take one of the four forms below, to listen on a TCP, UDP
   or UNIX domain socket. However, see the "Format" option for details on
-  transport support by different formats. Default: "udp://0.0.0.0:514"
+  transport support by different formats.
   
   * [hostname|ip]:<tcp-port>
   
@@ -31,6 +31,7 @@ Parameters
   * udp://<hostname|ip>:<udp-port>
   
   * unix://<filesystem-path>
+  By default this parameter is set to "udp://0.0.0.0:514"
   
   
 
@@ -46,6 +47,27 @@ Parameters
   * RFC5424 (https://tools.ietf.org/html/rfc5424) - unix, udp
   
   * RFC6587 (https://tools.ietf.org/html/rfc6587) - unix, upd, tcp
+  
+  By default this parameter is set to "RFC6587".
+  
+  
+
+**SetMetadata** (default: false)
+
+  When set to true, syslog based metadata will be attached to
+  the message. The metadata fields added depend on the protocol version used.
+  RFC3164 supports: tag, timestamp, hostname, priority, facility, severity.
+  RFC5424 and RFC6587 support: app_name, version, proc_id , msg_id, timestamp,
+  hostname, priority, facility, severity.
+  By default this parameter is set to "false".
+  
+  
+
+**TimestampFormat** (default: 2006-01-02T15:04:05.000 MST)
+
+  When using SetMetadata this string denotes the go time
+  format used to convert syslog timestamps into strings.
+  By default this parameter is set to "2006-01-02T15:04:05.000 MST".
   
   
 

--- a/docs/src/gen/formatter/metadatacopy.rst
+++ b/docs/src/gen/formatter/metadatacopy.rst
@@ -12,10 +12,36 @@ payload or from other metadata fields.
 Parameters
 ----------
 
+**Key**
+
+  Defines the key to copy, i.e. the "source". ApplyTo will define
+  the target of the copy, i.e. the "destination". An empty string will
+  use the message payload as source.
+  By default this parameter is set to an empty string (i.e. payload).
+  
+  
+
+**Mode**
+
+  Defines the copy mode to use. This can be one of "append",
+  "prepend" or "replace".
+  By default this parameter is set to "replace".
+  
+  
+
+**Separator**
+
+  When using mode prepend or append, defines the characters
+  inserted between source and destination.
+  By default this parameter is set to an empty string.
+  
+  
+
 **CopyToKeys**
 
-  A list of meta data keys to copy the payload or metadata
-  content to.
+  DEPRECATED. A list of meta data keys to copy the payload
+  or metadata content to. If this field contains at least one value, mode
+  is set to replace and the key field is ignored.
   By default this parameter is set to an empty list.
   
   
@@ -43,9 +69,8 @@ Parameters (from core.SimpleFormatter)
 Examples
 --------
 
-This example copies the payload to the fields prefix and key. The prefix
-field will extract everything up to the first space as hostname, the key
-field will contain a hash over the complete payload.
+This example copies the payload to the field key and applies a hash on
+it contain a hash over the complete payload.
 
 .. code-block:: yaml
 
@@ -54,11 +79,7 @@ field will contain a hash over the complete payload.
 	   Streams: "*"
 	   Modulators:
 	     - format.MetadataCopy:
-	       CopyToKeys: ["prefix", "key"]
-	     - format.SplitPick:
-	       ApplyTo: prefix
-	       Delimiter: " "
-	       Index: 0
+	       ApplyTo: key
 	     - formatter.Identifier
 	       Generator: hash
 	       ApplyTo: key

--- a/docs/src/gen/formatter/texttojson.rst
+++ b/docs/src/gen/formatter/texttojson.rst
@@ -230,7 +230,7 @@ The following example parses JSON data.
 	   Type: consumer.Console
 	   Streams: console
 	   Modulators:
-	     - format.JSON:
+	     - format.TextToJSON:
 	       Directives:
 	         - "findKey   :\":  key       :      :        "
 	         - "findKey   :}:             : pop  : end    "

--- a/format/metadatacopy.go
+++ b/format/metadatacopy.go
@@ -116,8 +116,6 @@ func (format *MetadataCopy) ApplyFormatter(msg *core.Message) error {
 	getSourceData := core.GetAppliedContentGetFunction(format.key)
 	srcData := getSourceData(msg)
 
-	println(format.key, ":", string(srcData))
-
 	switch format.mode {
 	case metadataCopyModeReplace:
 		format.SetAppliedContent(msg, srcData)

--- a/format/metadatacopy.go
+++ b/format/metadatacopy.go
@@ -15,6 +15,8 @@
 package format
 
 import (
+	"strings"
+
 	"github.com/trivago/gollum/core"
 )
 
@@ -25,34 +27,54 @@ import (
 //
 // Parameters
 //
-// - CopyToKeys: A list of meta data keys to copy the payload or metadata
-// content to.
+// - Key: Defines the key to copy, i.e. the "source". ApplyTo will define
+// the target of the copy, i.e. the "destination". An empty string will
+// use the message payload as source.
+// By default this parameter is set to an empty string (i.e. payload).
+//
+// - Mode: Defines the copy mode to use. This can be one of "append",
+// "prepend" or "replace".
+// By default this parameter is set to "replace".
+//
+// - Separator: When using mode prepend or append, defines the characters
+// inserted between source and destination.
+// By default this parameter is set to an empty string.
+//
+// - CopyToKeys: DEPRECATED. A list of meta data keys to copy the payload
+// or metadata content to. If this field contains at least one value, mode
+// is set to replace and the key field is ignored.
 // By default this parameter is set to an empty list.
 //
 // Examples
 //
-// This example copies the payload to the fields prefix and key. The prefix
-// field will extract everything up to the first space as hostname, the key
-// field will contain a hash over the complete payload.
+// This example copies the payload to the field key and applies a hash on
+// it contain a hash over the complete payload.
 //
 //  exampleConsumer:
 //    Type: consumer.Console
 //    Streams: "*"
 //    Modulators:
 //      - format.MetadataCopy:
-//        CopyToKeys: ["prefix", "key"]
-//      - format.SplitPick:
-//        ApplyTo: prefix
-//        Delimiter: " "
-//        Index: 0
+//        ApplyTo: key
 //      - formatter.Identifier
 //        Generator: hash
 //        ApplyTo: key
 //
 type MetadataCopy struct {
 	core.SimpleFormatter `gollumdoc:"embed_type"`
-	metaDataKeys         []string `config:"CopyToKeys"`
+	key                  string   `config:"Key"`
+	separator            []byte   `config:"Separator"`
+	metaDataKeys         []string `config:"CopyToKeys"` // deprecated
+	mode                 metadataCopyMode
 }
+
+type metadataCopyMode int
+
+const (
+	metadataCopyModeAppend  = metadataCopyMode(iota)
+	metadataCopyModeReplace = metadataCopyMode(iota)
+	metadataCopyModePrepend = metadataCopyMode(iota)
+)
 
 func init() {
 	core.TypeRegistry.Register(MetadataCopy{})
@@ -60,18 +82,60 @@ func init() {
 
 // Configure initializes this formatter with values from a plugin config.
 func (format *MetadataCopy) Configure(conf core.PluginConfigReader) {
+	mode := conf.GetString("Mode", "replace")
+	switch strings.ToLower(mode) {
+	case "replace":
+		format.mode = metadataCopyModeReplace
+	case "append":
+		format.mode = metadataCopyModeAppend
+	case "prepend":
+		format.mode = metadataCopyModePrepend
+	default:
+		conf.Errors.Pushf("mode must be one of replace, append or prepend")
+	}
 }
 
 // ApplyFormatter update message payload
 func (format *MetadataCopy) ApplyFormatter(msg *core.Message) error {
-	meta := msg.GetMetadata()
-	data := format.GetAppliedContent(msg)
-	pool := core.MessageDataPool
 
-	for _, key := range format.metaDataKeys {
-		bufferCopy := pool.Get(len(data))
-		copy(bufferCopy, data)
-		meta.SetValue(key, bufferCopy)
+	if len(format.metaDataKeys) > 0 {
+		// DEPRECATED
+		// This codepath will be removed in 0.6
+		meta := msg.GetMetadata()
+		data := format.GetAppliedContent(msg)
+		pool := core.MessageDataPool
+
+		for _, key := range format.metaDataKeys {
+			bufferCopy := pool.Get(len(data))
+			copy(bufferCopy, data)
+			meta.SetValue(key, bufferCopy)
+		}
+		return nil
 	}
+
+	getSourceData := core.GetAppliedContentGetFunction(format.key)
+	srcData := getSourceData(msg)
+
+	println(format.key, ":", string(srcData))
+
+	switch format.mode {
+	case metadataCopyModeReplace:
+		format.SetAppliedContent(msg, srcData)
+
+	case metadataCopyModePrepend:
+		dstData := format.GetAppliedContent(msg)
+		if len(format.separator) != 0 {
+			srcData = append(srcData, format.separator...)
+		}
+		format.SetAppliedContent(msg, append(srcData, dstData...))
+
+	case metadataCopyModeAppend:
+		dstData := format.GetAppliedContent(msg)
+		if len(format.separator) != 0 {
+			dstData = append(dstData, format.separator...)
+		}
+		format.SetAppliedContent(msg, append(dstData, srcData...))
+	}
+
 	return nil
 }

--- a/format/metadatacopy_test.go
+++ b/format/metadatacopy_test.go
@@ -7,7 +7,91 @@ import (
 	"github.com/trivago/tgo/ttesting"
 )
 
-func TestMetadataCopy(t *testing.T) {
+func TestMetadataCopyReplace(t *testing.T) {
+	expect := ttesting.NewExpect(t)
+
+	config := core.NewPluginConfig("", "format.MetadataCopy")
+	config.Override("Key", "foo")
+
+	plugin, err := core.NewPluginWithConfig(config)
+	expect.NoError(err)
+
+	formatter, casted := plugin.(*MetadataCopy)
+	expect.True(casted)
+
+	msg := core.NewMessage(nil, []byte("test"), core.Metadata{"foo": []byte("foo")}, core.InvalidStreamID)
+
+	err = formatter.ApplyFormatter(msg)
+	expect.NoError(err)
+
+	expect.Equal("foo", msg.String())
+}
+
+func TestMetadataCopyAddKey(t *testing.T) {
+	expect := ttesting.NewExpect(t)
+
+	config := core.NewPluginConfig("", "format.MetadataCopy")
+	config.Override("ApplyTo", "foo")
+
+	plugin, err := core.NewPluginWithConfig(config)
+	expect.NoError(err)
+
+	formatter, casted := plugin.(*MetadataCopy)
+	expect.True(casted)
+
+	msg := core.NewMessage(nil, []byte("test"), nil, core.InvalidStreamID)
+
+	err = formatter.ApplyFormatter(msg)
+	expect.NoError(err)
+
+	expect.Equal("test", msg.String())
+	expect.Equal("test", msg.GetMetadata().GetValueString("foo"))
+}
+
+func TestMetadataCopyAppend(t *testing.T) {
+	expect := ttesting.NewExpect(t)
+
+	config := core.NewPluginConfig("", "format.MetadataCopy")
+	config.Override("Key", "foo")
+	config.Override("Mode", "append")
+	config.Override("Separator", " ")
+
+	plugin, err := core.NewPluginWithConfig(config)
+	expect.NoError(err)
+
+	formatter, casted := plugin.(*MetadataCopy)
+	expect.True(casted)
+
+	msg := core.NewMessage(nil, []byte("test"), core.Metadata{"foo": []byte("foo")}, core.InvalidStreamID)
+
+	err = formatter.ApplyFormatter(msg)
+	expect.NoError(err)
+
+	expect.Equal("test foo", msg.String())
+}
+
+func TestMetadataCopyPrepend(t *testing.T) {
+	expect := ttesting.NewExpect(t)
+
+	config := core.NewPluginConfig("", "format.MetadataCopy")
+	config.Override("Key", "foo")
+	config.Override("Mode", "prepend")
+
+	plugin, err := core.NewPluginWithConfig(config)
+	expect.NoError(err)
+
+	formatter, casted := plugin.(*MetadataCopy)
+	expect.True(casted)
+
+	msg := core.NewMessage(nil, []byte("test"), core.Metadata{"foo": []byte("foo")}, core.InvalidStreamID)
+
+	err = formatter.ApplyFormatter(msg)
+	expect.NoError(err)
+
+	expect.Equal("footest", msg.String())
+}
+
+func TestMetadataCopyDeprecated(t *testing.T) {
 	expect := ttesting.NewExpect(t)
 
 	config := core.NewPluginConfig("", "format.MetadataCopy")
@@ -29,7 +113,7 @@ func TestMetadataCopy(t *testing.T) {
 	expect.Equal("test", msg.GetMetadata().GetValueString("bar"))
 }
 
-func TestMetadataCopyApplyToHandling(t *testing.T) {
+func TestMetadataCopyApplyToHandlingDeprecated(t *testing.T) {
 	expect := ttesting.NewExpect(t)
 
 	config := core.NewPluginConfig("", "format.MetadataCopy")

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean docker docker-dev install freebsd linux mac pi win current debug vendor test unit coverprofile integration example pre-commit vet lint fmt fmt-check ineffassign
 .DEFAULT_GOAL := current
 
-VERSION=0.5.0
+VERSION=0.5.1
 BUILD_ENV=GORACE="halt_on_error=0"
 BUILD_FLAGS=-ldflags=-s
 BUILD_DEBUG_FLAGS=-ldflags='-s -linkmode=internal' -gcflags='-N -l'


### PR DESCRIPTION
## The purpose of this pull request

This extends the format.MetadataCopy filter to make it more useful.
The version shipped with 0.5.0 supported only metadata keys as targets.
The new version will allow copying payload / metadata from and to any destination inside the message. However, the support for multiple targets has been dropped as it can be achieved by adding multiple instances of the filter.

## Config to verify

Append the value of a key to the payload
```yaml
format.MetadataCopy:
  Key: foo
  Mode: append
```

Copy the payload to a key (replace existing data)
```yaml
format.MetadataCopy:
  ApplyTo: key
```

## Checklist

- [x] `make test` executed successfully
- [x] unit test provided
- [x] docs updated
