### PR TITLE
Consumer.socket cleanup

### DIFF
--- a/testing/configs/test_socket.conf
+++ b/testing/configs/test_socket.conf
@@ -1,0 +1,26 @@
+SocketUdp:
+    Type: consumer.Socket
+    Streams: data
+    Address: udp://127.0.0.1:5880
+
+SocketTcp:
+    Type: consumer.Socket
+    Streams: data
+    Address: tcp://127.0.0.1:5881
+
+SocketTcpAck:
+    Type: consumer.Socket
+    Streams: data
+    Address: tcp://127.0.0.1:5882
+    Acknowledge: ACK
+
+SocketUDS:
+    Type: consumer.Socket
+    Streams: data
+    Address: unix:///tmp/integration.socket
+
+ConsoleOut:
+    Type: producer.Console
+    Streams: data
+    Modulators:
+        - format.Envelope

--- a/testing/integration/aasocket_test.go
+++ b/testing/integration/aasocket_test.go
@@ -1,0 +1,107 @@
+// +build integration
+
+package integration
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/trivago/tgo/ttesting"
+)
+
+const (
+	TestConfigSocket = "test_socket.conf"
+)
+
+func TestSocketWriteSocket(t *testing.T) {
+	setup()
+	expect := ttesting.NewExpect(t)
+
+	// execute gollum
+	cmd, err := StartGollum(TestConfigSocket, "-ll=2")
+	expect.NoError(err)
+
+	udp, err := net.Dial("udp", "127.0.0.1:5880")
+	expect.NoError(err)
+
+	socket, err := net.Dial("unix", "/tmp/integration.socket")
+	expect.NoError(err)
+
+	tcp, err := net.Dial("tcp", "127.0.0.1:5881")
+	expect.NoError(err)
+
+	tcpAck, err := net.Dial("tcp", "127.0.0.1:5882")
+	expect.NoError(err)
+
+	udp.SetWriteDeadline(time.Now().Add(time.Second))
+	_, err = udp.Write([]byte("### test UDP\n"))
+	udp.Close()
+	expect.NoError(err)
+
+	socket.SetWriteDeadline(time.Now().Add(time.Second))
+	_, err = socket.Write([]byte("### test Socket\n"))
+	socket.Close()
+	expect.NoError(err)
+
+	tcp.SetWriteDeadline(time.Now().Add(time.Second))
+	_, err = tcp.Write([]byte("### test TCP\n"))
+	tcp.Close()
+	expect.NoError(err)
+
+	tcpAck.SetWriteDeadline(time.Now().Add(time.Second))
+	_, err = tcpAck.Write([]byte("### test ACK\n"))
+	expect.NoError(err)
+
+	buffer := make([]byte, 8)
+	tcpAck.SetReadDeadline(time.Now().Add(time.Second))
+	n, err := tcpAck.Read(buffer)
+
+	tcpAck.Close()
+	expect.NoError(err)
+	expect.Equal([]byte("ACK"), buffer[:n])
+
+	out := StopGollum(cmd)
+
+	buffer = make([]byte, 4096)
+	n, err = out.Read(buffer)
+	expect.NoError(err)
+
+	text := string(buffer[:n])
+	expect.Contains(text, "### test UDP")
+	expect.Contains(text, "### test Socket")
+	expect.Contains(text, "### test TCP")
+	expect.Contains(text, "### test ACK")
+}
+
+func TestSocketCleanup(t *testing.T) {
+	setup()
+	expect := ttesting.NewExpect(t)
+
+	// execute gollum
+	cmd, err := StartGollum(TestConfigSocket, "-ll=3")
+	expect.NoError(err)
+
+	socket, err := net.Dial("unix", "/tmp/integration.socket")
+	expect.NoError(err)
+
+	tcp, err := net.Dial("tcp", "127.0.0.1:5881")
+	expect.NoError(err)
+
+	var out *bytes.Buffer
+	expect.NonBlocking(10*time.Second, func() {
+		out = StopGollum(cmd)
+	})
+
+	buffer := make([]byte, 8192)
+	_, err = out.Read(buffer)
+	expect.NoError(err)
+
+	_, err = socket.Write(buffer)
+	expect.NotNil(err)
+
+	tcp.Write(buffer)
+	_, err = tcp.Read(buffer)
+	expect.NotNil(err)
+}


### PR DESCRIPTION
## The purpose of this pull request

Clean up the codebase for consumer.socket.
This also fixes a bug where gollum would hang during shutdown while trying to open a new connection. In addition to this a lot more debug output has been added and all errors are properly passed to logrus.

There are a few breaking changes on the configuration that require a mention:
 * AckTimoutSec is now AckTimeoutSec
 * ReadTimoutSec is now ReadTimeoutSec
 * An empty value on Acknowledge does not force UDP anymore
 * Using Acknowledge with UDP will cause an error
 * Default protocol is now TCP (not affected by Acknowledge anymore)

## Config to verify

<!--- Provide a config to verify/test this pull request -->

```yaml
SocketUdp:
    Type: consumer.Socket
    Streams: data
    Address: udp://127.0.0.1:5880

SocketTcp:
    Type: consumer.Socket
    Streams: data
    Address: tcp://127.0.0.1:5881

SocketTcpAck:
    Type: consumer.Socket
    Streams: data
    Address: tcp://127.0.0.1:5882
    Acknowledge: ACK

SocketUDS:
    Type: consumer.Socket
    Streams: data
    Address: unix:///tmp/integration.socket

ConsoleOut:
    Type: producer.Console
    Streams: data
    Modulators:
        - format.Envelope
```


## Checklist

- [x] `make test` executed successfully
- [x] integration test provided
- [x] docs updated
