### PR TITLE
commit offsets to kafka when using consumer groups

### DIFF
--- a/consumer/kafka.go
+++ b/consumer/kafka.go
@@ -397,8 +397,11 @@ func (cons *Kafka) readFromGroup() {
 
 	for !cons.groupClient.Closed() {
 		select {
-		case event := <-consumer.Messages():
-			cons.enqueueEvent(event)
+		case event, ok := <-consumer.Messages():
+			if ok {
+				cons.enqueueEvent(event)
+				consumer.MarkOffset(msg, "")
+			}
 
 		case err := <-consumer.Errors():
 			defer cons.restartGroup()

--- a/consumer/kafka.go
+++ b/consumer/kafka.go
@@ -400,7 +400,7 @@ func (cons *Kafka) readFromGroup() {
 		case event, ok := <-consumer.Messages():
 			if ok {
 				cons.enqueueEvent(event)
-				consumer.MarkOffset(msg, "")
+				consumer.MarkOffset(event, "")
 			}
 
 		case err := <-consumer.Errors():


### PR DESCRIPTION
## The purpose of this pull request

In order to have consumer groups not start from the beginning if they all crash, and to be able monitor where they are; consumers need to commit their offsets. Technically consumer groups work without them, however it can lead to some unwanted behavior in failure scenarios.

## Config to verify

<!--- Provide a config to verify/test this pull request -->

```yaml
kafkaIn:
  Type: consumer.Kafka
  Streams: logs
  Topic: logs
  ClientId: "gollum log reader"
  GroupId: "gollum"
  Servers:
    - "kafka0:9092"
    - "kafka1:9092"
    - "kafka2:9092"
    - "kafka3:9092"
```


## Checklist
<!--
Mark everything that applies:
-->

- [x] `make test` executed successfully
- [ ] unit test provided
- [ ] integration test provided
- [ ] docs updated
