### PR TITLE
fixes #229: format.MetadataCopy integrity

### DIFF
--- a/format/metadatacopy.go
+++ b/format/metadatacopy.go
@@ -115,23 +115,26 @@ func (format *MetadataCopy) ApplyFormatter(msg *core.Message) error {
 	getSourceData := core.GetAppliedContentGetFunction(format.key)
 	srcData := getSourceData(msg)
 
+	cloneSrcData := make([]byte, len(srcData))
+	copy(cloneSrcData, srcData)
+
 	switch format.mode {
 	case metadataCopyModeReplace:
-		format.SetAppliedContent(msg, srcData)
+		format.SetAppliedContent(msg, cloneSrcData)
 
 	case metadataCopyModePrepend:
 		dstData := format.GetAppliedContent(msg)
 		if len(format.separator) != 0 {
-			srcData = append(srcData, format.separator...)
+			cloneSrcData = append(cloneSrcData, format.separator...)
 		}
-		format.SetAppliedContent(msg, append(srcData, dstData...))
+		format.SetAppliedContent(msg, append(cloneSrcData, dstData...))
 
 	case metadataCopyModeAppend:
 		dstData := format.GetAppliedContent(msg)
 		if len(format.separator) != 0 {
 			dstData = append(dstData, format.separator...)
 		}
-		format.SetAppliedContent(msg, append(dstData, srcData...))
+		format.SetAppliedContent(msg, append(dstData, cloneSrcData...))
 	}
 
 	return nil

--- a/format/metadatacopy_test.go
+++ b/format/metadatacopy_test.go
@@ -136,3 +136,56 @@ func TestMetadataCopyApplyToHandlingDeprecated(t *testing.T) {
 	expect.Equal("meta", msg.GetMetadata().GetValueString("foo"))
 	expect.Equal("meta", msg.GetMetadata().GetValueString("bar"))
 }
+
+func TestMetadataCopyMetadataIntegrity(t *testing.T) {
+	expect := ttesting.NewExpect(t)
+
+	config := core.NewPluginConfig("", "format.MetadataCopy")
+	config.Override("ApplyTo", "foo")
+
+	plugin, err := core.NewPluginWithConfig(config)
+	expect.NoError(err)
+
+	formatter, casted := plugin.(*MetadataCopy)
+	expect.True(casted)
+
+	msg := core.NewMessage(nil, []byte("payload"), nil, core.InvalidStreamID)
+
+	err = formatter.ApplyFormatter(msg)
+	expect.NoError(err)
+
+	expect.Equal("payload", msg.String())
+	expect.Equal("payload", msg.GetMetadata().GetValueString("foo"))
+
+	msg.StorePayload([]byte("xxx"))
+
+	expect.Equal("xxx", msg.String())
+	expect.Equal("payload", msg.GetMetadata().GetValueString("foo"))
+}
+
+func TestMetadataCopyPayloadIntegrity(t *testing.T) {
+	expect := ttesting.NewExpect(t)
+
+	config := core.NewPluginConfig("", "format.MetadataCopy")
+	config.Override("Key", "foo")
+
+	plugin, err := core.NewPluginWithConfig(config)
+	expect.NoError(err)
+
+	formatter, casted := plugin.(*MetadataCopy)
+	expect.True(casted)
+
+	msg := core.NewMessage(nil, []byte{}, nil, core.InvalidStreamID)
+	msg.GetMetadata().SetValue("foo", []byte("metadata"))
+
+	err = formatter.ApplyFormatter(msg)
+	expect.NoError(err)
+
+	expect.Equal("metadata", msg.String())
+	expect.Equal("metadata", msg.GetMetadata().GetValueString("foo"))
+
+	msg.GetMetadata().SetValue("foo", []byte("xxx"))
+
+	expect.Equal("metadata", msg.String())
+	expect.Equal("xxx", msg.GetMetadata().GetValueString("foo"))
+}


### PR DESCRIPTION
## The purpose of this pull request
Fixes of issue #229 
## Config to verify
```yaml
default-input:
    Type: producer.Console
    Streams:
        - console

default-output:
    Type: consumer.Console
    Streams:
        - console
    Modulators:
        ## Suppose that payload is 'aaaa:bb'
        ## Copy payload to metadata['key']
        ## So metadata['key'] is now 'aaaa:bb'  and payload is 'aaaa:bb' as well
        - format.MetadataCopy:
            ApplyTo: key

       ## Split the payload and pick index 1
       ## So metadata['key'] is now 'aaaa:bb' and payload is 'bb'
        - format.SplitPick:
            Index: 1
            Delimiter: ':'

       ## In order to print value of metadata prepend it to message payload
       ## So metadata['key'] must be 'aaaa:bb' and payload be 'key#payload' 
       ## which is 'aaaa:bb#bb'
        - format.MetadataCopy:
            Key: key
            Separator: '#'
            Mode: prepend
       
       ## Final payload must be 'aaaa:bb#bb'
        - format.Envelope:
            Postfix: "\n"
```
## Checklist

- [x] `make test` executed successfully
- [x] unit test provided
- [ ] integration test provided
- [ ] docs updated
