### PR TITLE
Allow non-standard protocols for syslog consumer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ Please read the release notes carefully
 
 ### New with 0.6.0
 
- * Added a new flag "-mt" to choose the metrics provider (currently only prometheus)
+ * Added a new flag "-mt" to choose the metrics provider (currently only prometheus).
  * Consumer.File setting "Files" now supports glob patterns.
+ * Consumer.Syslog now allows non-standard protocol types (see issue #234)
 
 ### Breaking changes with 0.6.0
 

--- a/consumer/syslogd.go
+++ b/consumer/syslogd.go
@@ -111,17 +111,15 @@ func (cons *Syslogd) Configure(conf core.PluginConfigReader) {
 	// http://www.ietf.org/rfc/rfc3164.txt
 	case "RFC3164":
 		cons.format = syslog.RFC3164
-		if cons.protocol == "tcp" {
-			cons.Logger.Warning("RFC3164 demands UDP")
-			cons.protocol = "udp"
+		if cons.protocol != "udp" {
+			cons.Logger.Infof("Using '%s' instead of 'udp' for RFC3164 violates the standard", cons.protocol)
 		}
 
 	// https://tools.ietf.org/html/rfc5424
 	case "RFC5424":
 		cons.format = syslog.RFC5424
-		if cons.protocol == "tcp" {
-			cons.Logger.Warning("RFC5424 demands UDP")
-			cons.protocol = "udp"
+		if cons.protocol != "udp" {
+			cons.Logger.Infof("Using '%s' instead of 'udp' for RFC5424 violates the standard", cons.protocol)
 		}
 
 	// https://tools.ietf.org/html/rfc6587


### PR DESCRIPTION
Referring to #234.
A non-standard protocol will be logged as "info" because it does not break anything.