### PR TITLE
Change the message timestamp type from time.Time to int64.

### DIFF
--- a/core/message.go
+++ b/core/message.go
@@ -36,7 +36,7 @@ type Message struct {
 	prevStreamID MessageStreamID
 	origStreamID MessageStreamID
 	source       MessageSource
-	timestamp    time.Time
+	timestamp    int64
 }
 
 // NewMessage creates a new message from a given data stream by copying data.
@@ -45,7 +45,7 @@ func NewMessage(source MessageSource, data []byte, metadata Metadata, streamID M
 		source:       source,
 		streamID:     streamID,
 		origStreamID: streamID,
-		timestamp:    time.Now(),
+		timestamp:    time.Now().UnixNano(),
 	}
 
 	msg.data.payload = getPayloadCopy(data)
@@ -65,7 +65,9 @@ func getPayloadCopy(data []byte) (buffer []byte) {
 
 // GetCreationTime returns the time when this message was created.
 func (msg *Message) GetCreationTime() time.Time {
-	return msg.timestamp
+	sec := msg.timestamp / 1e9
+	nano := msg.timestamp - sec*1e9
+	return time.Unix(sec, nano)
 }
 
 // GetStreamID returns the stream this message is currently routed to.
@@ -243,7 +245,7 @@ func (msg *Message) Serialize() ([]byte, error) {
 		StreamID:     proto.Uint64(uint64(msg.GetStreamID())),
 		PrevStreamID: proto.Uint64(uint64(msg.GetPrevStreamID())),
 		OrigStreamID: proto.Uint64(uint64(msg.GetOrigStreamID())),
-		Timestamp:    proto.Int64(msg.timestamp.UnixNano()),
+		Timestamp:    proto.Int64(msg.timestamp),
 		Data: &SerializedMessageData{
 			Data:     msg.data.payload,
 			Metadata: msg.data.metadata,
@@ -269,15 +271,11 @@ func DeserializeMessage(data []byte) (*Message, error) {
 		return nil, err
 	}
 
-	timestamp := serializable.GetTimestamp()
-	timestampSec := timestamp / 1e9
-	timestampNano := timestamp - timestampSec*1e9
-
 	msg := &Message{
 		streamID:     MessageStreamID(serializable.GetStreamID()),
 		prevStreamID: MessageStreamID(serializable.GetPrevStreamID()),
 		origStreamID: MessageStreamID(serializable.GetOrigStreamID()),
-		timestamp:    time.Unix(timestampSec, timestampNano),
+		timestamp:    serializable.GetTimestamp(),
 	}
 
 	if msgData := serializable.GetData(); msgData != nil {

--- a/core/message_test.go
+++ b/core/message_test.go
@@ -25,7 +25,7 @@ func getMockMessage(data string) *Message {
 	msg := &Message{
 		prevStreamID: 2,
 		source:       nil,
-		timestamp:    time.Now(),
+		timestamp:    time.Now().UnixNano(),
 	}
 
 	msg.data.payload = []byte(data)
@@ -211,7 +211,7 @@ func TestMessageSerialize(t *testing.T) {
 	expect.Equal(readMessage.streamID, testMessage.streamID)
 	expect.Equal(readMessage.prevStreamID, testMessage.prevStreamID)
 	expect.Equal(readMessage.origStreamID, testMessage.origStreamID)
-	expect.Equal(readMessage.timestamp.UnixNano(), testMessage.timestamp.UnixNano())
+	expect.Equal(readMessage.timestamp, testMessage.timestamp)
 	expect.Equal(readMessage.data.payload, testMessage.data.payload)
 	expect.Equal(readMessage.data.metadata, testMessage.data.metadata)
 	expect.Nil(readMessage.orig)
@@ -230,7 +230,7 @@ func TestMessageSerialize(t *testing.T) {
 	expect.Equal(readMessage.streamID, testMessage.streamID)
 	expect.Equal(readMessage.prevStreamID, testMessage.prevStreamID)
 	expect.Equal(readMessage.origStreamID, testMessage.origStreamID)
-	expect.Equal(readMessage.timestamp.UnixNano(), testMessage.timestamp.UnixNano())
+	expect.Equal(readMessage.timestamp, testMessage.timestamp)
 	expect.Equal(readMessage.data.payload, testMessage.data.payload)
 	expect.Equal(readMessage.data.metadata, testMessage.data.metadata)
 	expect.NotNil(readMessage.orig)

--- a/core/messagetracer.go
+++ b/core/messagetracer.go
@@ -17,9 +17,10 @@ package core
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"hash/fnv"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 type messageTracer struct {
@@ -156,8 +157,7 @@ func (mt *messageTracer) newMessageDump(msg *Message, comment string) messageDum
 	}
 
 	//  set timestamp
-	dump.Timestamp = msg.timestamp
-
+	dump.Timestamp = msg.GetCreationTime()
 	dump.FingerprintID = mt.createFingerPrintID(&dump)
 
 	return dump


### PR DESCRIPTION
- This will reduce the message size by a few bytes.
- Makes serialize/deserialize a bit easier.
- Gives a small performance increase on high throughput scenarios.
