### PR TITLE
fixed error when using OffsetFilePath in consumer.File

### DIFF
--- a/consumer/file.go
+++ b/consumer/file.go
@@ -232,7 +232,7 @@ func (cons *File) observeFile(name string, stopIfNotExist bool) {
 
 	if cons.offsetFilePath != "" {
 		enqueue = func(data []byte) {
-			enqueue(data)
+			cons.Enqueue(data)
 			file.storeOffset()
 		}
 	}

--- a/consumer/fileobservable.go
+++ b/consumer/fileobservable.go
@@ -95,7 +95,6 @@ func (fs *observableFile) saveOffset(offset int64) {
 	if err := ioutil.WriteFile(fs.offsetFileName, []byte(offsetAsString), 0644); err != nil {
 		fs.log.WithError(err).Error("Failed to store offset")
 	}
-	fs.log.Info("Offset file reseted")
 }
 
 func (fs *observableFile) scrape(fileName string, enqueue func([]byte), onRotate func()) {
@@ -129,6 +128,7 @@ func (fs *observableFile) scrape(fileName string, enqueue func([]byte), onRotate
 			fs.cursor.whence = io.SeekStart
 			fs.cursor.offset = 0
 			fs.saveOffset(fs.cursor.offset)
+			fs.log.Info("Offset file reseted")
 			onRotate()
 		}
 	default:

--- a/consumer/fileobservable.go
+++ b/consumer/fileobservable.go
@@ -87,10 +87,15 @@ func (fs *observableFile) hasRotated(currentName string) bool {
 
 func (fs *observableFile) storeOffset() {
 	fs.cursor.offset, _ = fs.handle.Seek(0, io.SeekCurrent)
-	offsetAsString := strconv.FormatInt(fs.cursor.offset, 10)
+	fs.saveOffset(fs.cursor.offset)
+}
+
+func (fs *observableFile) saveOffset(offset int64) {
+	offsetAsString := strconv.FormatInt(offset, 10)
 	if err := ioutil.WriteFile(fs.offsetFileName, []byte(offsetAsString), 0644); err != nil {
 		fs.log.WithError(err).Error("Failed to store offset")
 	}
+	fs.log.Info("Offset file reseted")
 }
 
 func (fs *observableFile) scrape(fileName string, enqueue func([]byte), onRotate func()) {
@@ -123,7 +128,7 @@ func (fs *observableFile) scrape(fileName string, enqueue func([]byte), onRotate
 
 			fs.cursor.whence = io.SeekStart
 			fs.cursor.offset = 0
-
+			fs.saveOffset(fs.cursor.offset)
 			onRotate()
 		}
 	default:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

## The purpose of this pull request
fix bug when using OffsetFilePath option for consumer.File

## Config to verify

```yaml
"Fileinput":
  Type: "consumer.File"
  Files: /tmp/portal2Service.log
  OffsetFilePath: "/tmp"
  DefaultOffset: "oldest"
  Delimiter: '^\d{4}-\d{2}-\d{2}T'
  Streams:
    - elastic
  Modulators:
    - format.GrokToJSON:
        Patterns:
          - '%{TIMESTAMP_ISO8601:timestamp} %{IP:client_ip}?\s*\[%{USERNAME:thread_id}\] %{DATA:uid} %{LOGLEVEL:log_level} \s*?%{USERNAME:service_name} -\s*(?s)%{GREEDYDATA:rest}'

"producer.Console":
  Type: producer.Console
  Streams:
    - "elastic"
  Modulators:
    - format.Envelope:
        Prefix: "\n"
        Postfix: "\n"

```


## Checklist
<!--
Mark everything that applies:
-->

- [ ] `make test` executed successfully
'make test' not running successfully on master branch of main repo
- [ ] unit test provided
- [ ] integration test provided
- [ ] docs updated
