### PR TITLE
Add the possibility to filter file globs by regex.

### DIFF
--- a/consumer/file.go
+++ b/consumer/file.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -114,13 +115,27 @@ const (
 // performance impact on systems with high throughput.
 // By default this parameter is set to "false".
 //
+// - BlackList: A regular expression matching file paths to NOT read. When both
+// BlackList and WhiteList are defined, the WhiteList takes precedence.
+// This setting is only used when glob expressions (*, ?) are present in the
+// filename. The path checked is the one before symlink evaluation.
+// By default this parameter is set to "".
+//
+// - WhiteList: A regular expression matching file paths to read. When both
+// BlackList and WhiteList are defined, the WhiteList takes precedence.
+// This setting is only used when glob expressions (*, ?) are present in the
+// filename. The path checked is the one before symlink evaluation.
+// By default this parameter is set to "".
+//
 // Examples
 //
-// This example will read the `/var/log/system.log` file and create a message for each new entry.
+// This example will read all the `.log` files `/var/log/` into one stream and
+// create a message for each new entry. If the file starts with `sys` it is ignored
 //
 //  FileIn:
 //    Type: consumer.File
 //    File: /var/log/*.log
+//    BlackList '^sys.*'
 //    DefaultOffset: newest
 //    OffsetFilePath: ""
 //    Delimiter: "\n"
@@ -139,9 +154,13 @@ type File struct {
 	observeMode      string        `config:"ObserveMode" default:"poll"`
 	hasToSetMetadata bool          `config:"SetMetadata" default:"false"`
 	defaultOffset    string        `config:"DefaultOffset" default:"newest"`
+	blackListString  string        `config:"BlackList"`
+	whiteListString  string        `config:"WhiteList"`
 
 	observedFiles *sync.Map
 	done          chan struct{}
+	blackList     *regexp.Regexp
+	whiteList     *regexp.Regexp
 }
 
 func init() {
@@ -164,6 +183,15 @@ func (cons *File) Configure(conf core.PluginConfigReader) {
 		cons.Logger.Warningf("Unknown observe mode '%s'. Using poll", cons.observeMode)
 		cons.observeMode = observeModePoll
 	}
+
+	var err error
+	if len(cons.blackListString) > 0 {
+		cons.blackList, err = regexp.Compile(cons.blackListString)
+	}
+	if len(cons.whiteListString) > 0 {
+		cons.whiteList, err = regexp.Compile(cons.whiteListString)
+	}
+	conf.Errors.Push(err)
 }
 
 func (cons *File) newObservedFile(name string, stopIfNotExist bool) *observableFile {
@@ -245,6 +273,20 @@ func (cons *File) observeFile(name string, stopIfNotExist bool) {
 	}
 }
 
+func (cons *File) isBlacklisted(filename string) bool {
+	// netiher black or whitelisted? pass
+	if cons.blackList == nil && cons.whiteList == nil {
+		return false
+	}
+
+	// At this point either a black or whitelist exists
+
+	blacklisted := cons.blackList != nil && cons.blackList.MatchString(filename)
+	notWhiteListed := cons.whiteList == nil || !cons.whiteList.MatchString(filename)
+
+	return blacklisted && notWhiteListed
+}
+
 func (cons *File) observeFiles() {
 	defer cons.WorkerDone()
 
@@ -263,6 +305,10 @@ func (cons *File) observeFiles() {
 
 		cons.Logger.Debugf("Evaluating glob returned %d files to scrape", len(fileNames))
 		for i := range fileNames {
+			if cons.isBlacklisted(fileNames[i]) {
+				continue
+			}
+
 			if _, ok := cons.observedFiles.Load(fileNames[i]); !ok {
 				cons.AddWorker()
 				go cons.observeFile(fileNames[i], stopIfNotExist)

--- a/docs/src/gen/consumer/file.rst
+++ b/docs/src/gen/consumer/file.rst
@@ -124,6 +124,26 @@ Parameters
   
   
 
+**BlackList**
+
+  A regular expression matching file paths to NOT read. When both
+  BlackList and WhiteList are defined, the WhiteList takes precedence.
+  This setting is only used when glob expressions (*, ?) are present in the
+  filename. The path checked is the one before symlink evaluation.
+  By default this parameter is set to "".
+  
+  
+
+**WhiteList**
+
+  A regular expression matching file paths to read. When both
+  BlackList and WhiteList are defined, the WhiteList takes precedence.
+  This setting is only used when glob expressions (*, ?) are present in the
+  filename. The path checked is the one before symlink evaluation.
+  By default this parameter is set to "".
+  
+  
+
 **Files** (default: /var/log/*.log)
 
   (no documentation available)
@@ -182,13 +202,15 @@ Parameters (from core.SimpleConsumer)
 Examples
 --------
 
-This example will read the `/var/log/system.log` file and create a message for each new entry.
+This example will read all the `.log` files `/var/log/` into one stream and
+create a message for each new entry. If the file starts with `sys` it is ignored
 
 .. code-block:: yaml
 
 	 FileIn:
 	   Type: consumer.File
 	   File: /var/log/*.log
+	   BlackList '^sys.*'
 	   DefaultOffset: newest
 	   OffsetFilePath: ""
 	   Delimiter: "\n"

--- a/testing/configs/test_file_consumer_black.conf
+++ b/testing/configs/test_file_consumer_black.conf
@@ -1,0 +1,14 @@
+BlackIn:
+    Type: "consumer.File"
+    Files: "/tmp/gollum_test_glob*.log"
+    BlackList: "gollum_test_glob[2-9]"
+    DefaultOffset: oldest
+    Streams: black
+
+BlackOut:
+    Type: "producer.File"
+    Streams: black
+    File: /tmp/gollum_test.log
+    Batch:
+        TimeoutSec: 1
+        FlushCount: 1

--- a/testing/configs/test_file_consumer_blackwhite.conf
+++ b/testing/configs/test_file_consumer_blackwhite.conf
@@ -1,0 +1,15 @@
+BlackIn:
+    Type: "consumer.File"
+    Files: "/tmp/gollum_test_glob*.log"
+    BlackList: "gollum_test_glob[1-9]"
+    WhiteList: "gollum_test_glob1"
+    DefaultOffset: oldest
+    Streams: black
+
+BlackOut:
+    Type: "producer.File"
+    Streams: black
+    File: /tmp/gollum_test.log
+    Batch:
+        TimeoutSec: 1
+        FlushCount: 1

--- a/testing/configs/test_file_consumer_white.conf
+++ b/testing/configs/test_file_consumer_white.conf
@@ -1,0 +1,14 @@
+WhiteIn:
+    Type: "consumer.File"
+    Files: "/tmp/*.log"
+    WhiteList: "gollum_test_glob[01]"
+    DefaultOffset: oldest
+    Streams: white
+
+WhiteOut:
+    Type: "producer.File"
+    Streams: white
+    File: /tmp/gollum_test.log
+    Batch:
+        TimeoutSec: 1
+        FlushCount: 1

--- a/testing/integration/resultfile.go
+++ b/testing/integration/resultfile.go
@@ -14,6 +14,9 @@ const (
 	tmpTestFilePathDefault = "/tmp/gollum_test.log"
 	tmpTestFilePathFoo     = "/tmp/gollum_test_foo.log"
 	tmpTestFilePathBar     = "/tmp/gollum_test_bar.log"
+	tmpTestFilePathGlob0   = "/tmp/gollum_test_glob0.log"
+	tmpTestFilePathGlob1   = "/tmp/gollum_test_glob1.log"
+	tmpTestFilePathGlob2   = "/tmp/gollum_test_glob2.log"
 )
 
 var (
@@ -21,6 +24,9 @@ var (
 		tmpTestFilePathDefault,
 		tmpTestFilePathFoo,
 		tmpTestFilePathBar,
+		tmpTestFilePathGlob0,
+		tmpTestFilePathGlob1,
+		tmpTestFilePathGlob2,
 	}
 )
 


### PR DESCRIPTION
This is an improvement over removing files from the streams after they have been scraped. For larger file scrapings (e.g. kubernetes logs) this will result in less overhead.

## Config to verify

```yaml
logConsumer:
  Type: consumer.File
  Files: /var/log/*.log
  BlackList: 'wifi.*'
  WhiteList: 'wifi\..*'
  Streams: out

out:
  Type: producer.Console
  Streams: out
```

When used on a mac this will read all logs and the `wifi.log` file, but not files like `wifi-03-29-2019__10:58:44.764.log`. You can modify black and white list to achieve different results.

## Checklist

- [x] `make test` executed successfully
- [ ] unit test provided
- [x] integration test provided
- [x] docs updated
