### PR TITLE
Fix empty metadata after message cloning

### DIFF
--- a/core/message.go
+++ b/core/message.go
@@ -177,10 +177,8 @@ func (msg *Message) CloneOriginal() *Message {
 	clone.data.payload = make([]byte, len(msg.orig.payload))
 	copy(clone.data.payload, msg.orig.payload)
 
-	if msg.orig.metadata == nil {
+	if msg.orig.metadata != nil {
 		clone.data.metadata = msg.orig.metadata.Clone()
-	} else {
-		clone.data.metadata = nil
 	}
 
 	clone.SetStreamID(msg.origStreamID)

--- a/core/message_test.go
+++ b/core/message_test.go
@@ -156,9 +156,9 @@ func TestMessageCloneOriginalMetadata(t *testing.T) {
 	msg.StorePayload([]byte(msgUpdateString))
 	msg.GetMetadata().SetValue("foo", []byte("bar"))
 
-	msg.CloneOriginal()
+	clone := msg.CloneOriginal()
 
-	expect.Equal("bar", msg.GetMetadata().GetValueString("foo"))
+	expect.Equal("bar", clone.GetMetadata().GetValueString("foo"))
 }
 
 func TestMessageMetadata(t *testing.T) {


### PR DESCRIPTION

## The purpose of this pull request

- fixed cloning metadata
- fixed unit test for cloning metadata

## Checklist
<!--
Mark everything that applies:
-->

- [x] `make test` executed successfully
- [x] unit test provided
