### PR TITLE
Fix spoolfile message formatting

### DIFF
--- a/producer/socket.go
+++ b/producer/socket.go
@@ -181,7 +181,7 @@ func (prod *Socket) sendBatch() {
 	// Flush the buffer to the connection if it is active
 	if prod.tryConnect() {
 		prod.batch.Flush(prod.assembly.Write)
-	} else if prod.IsStopping() {
+	} else {
 		prod.batch.Flush(prod.assembly.Flush)
 	}
 }

--- a/producer/spoolfile.go
+++ b/producer/spoolfile.go
@@ -242,7 +242,7 @@ func (spool *spoolFile) read() {
 		spool.reader.Reset(0)
 
 		// Any error cancels the loop
-		if err := spool.reader.ReadAll(file, spool.decode); err != io.EOF {
+		if err := spool.reader.ReadAll(file, spool.decode); err != io.EOF && err != nil {
 			spool.prod.Logger.WithError(err).Error("failed to read spooling file ", spoolFileName)
 			if err := file.Close(); err != nil {
 				spool.prod.Logger.WithError(err).Error("failed to close spooling file ", spoolFileName)

--- a/producer/spooling.go
+++ b/producer/spooling.go
@@ -196,7 +196,7 @@ func (prod *Spooling) writeToFile(msg *core.Message) {
 	// Convert to expected payload format
 	encodedPayload, err := prod.encode(msg)
 	if err != nil {
-		prod.Logger.WithError(err).Error("Failed to encoded messager for spooling")
+		prod.Logger.WithError(err).Error("Failed to encode message for spooling")
 		prod.TryFallback(msg)
 		return // ### return, could not spool to disk ###
 	}

--- a/producer/spooling.go
+++ b/producer/spooling.go
@@ -258,11 +258,10 @@ func (prod *Spooling) routeToOrigin(msg *core.Message) {
 }
 
 func (prod *Spooling) waitForReader() {
-	prod.outfileGuard.Lock()
-	defer prod.outfileGuard.Unlock()
+	prod.outfileGuard.RLock()
+	defer prod.outfileGuard.RUnlock()
 
-	outfiles := prod.outfile
-	for _, spool := range outfiles {
+	for _, spool := range prod.outfile {
 		spool.waitForReader()
 	}
 }
@@ -276,8 +275,9 @@ func (prod *Spooling) close() {
 	}
 	prod.DefaultClose()
 
-	prod.outfileGuard.Lock()
-	defer prod.outfileGuard.Unlock()
+	prod.outfileGuard.RLock()
+	defer prod.outfileGuard.RUnlock()
+
 	for _, spool := range prod.outfile {
 		spool.close()
 	}

--- a/producer/spooling.go
+++ b/producer/spooling.go
@@ -15,13 +15,14 @@
 package producer
 
 import (
+	"encoding/base64"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
-	"github.com/rcrowley/go-metrics"
+	metrics "github.com/rcrowley/go-metrics"
 
 	"github.com/trivago/gollum/core"
 	"github.com/trivago/gollum/core/components"
@@ -107,7 +108,6 @@ type Spooling struct {
 	batchTimeout          time.Duration           `config:"Batch/TimeoutSec" default:"5" metric:"sec"`
 	readDelay             time.Duration
 	spoolCheck            *time.Timer
-	serialze              core.Formatter
 	metricsRegistry       metrics.Registry
 }
 
@@ -121,14 +121,6 @@ func (prod *Spooling) Configure(conf core.PluginConfigReader) {
 	prod.SetStopCallback(prod.close)
 	prod.SetRollCallback(prod.onRoll)
 	prod.metricsRegistry = core.NewMetricsRegistryForPlugin(prod)
-
-	serializePlugin, err := core.NewPluginWithConfig(core.NewPluginConfig("", "format.Serialize"))
-	conf.Errors.Push(err)
-	if serializeFormatter, isFormatter := serializePlugin.(core.Formatter); isFormatter {
-		prod.serialze = serializeFormatter
-	} else {
-		conf.Errors.Pushf("Failed to instantiate format.Serialize")
-	}
 
 	prod.outfileGuard = new(sync.RWMutex)
 	prod.outfile = make(map[core.MessageStreamID]*spoolFile)
@@ -146,19 +138,27 @@ func (prod *Spooling) Configure(conf core.PluginConfigReader) {
 	prod.rotation.SizeByte = prod.maxFileSize
 }
 
-// Modulate enforces the serialize formatter at the end of the modulation chain
-func (prod *Spooling) Modulate(msg *core.Message) core.ModulateResult {
-	result := prod.BufferedProducer.Modulate(msg)
-	prod.serialze.ApplyFormatter(msg) // Ignore result
-	return result
-}
-
 // TryFallback reverts the message stream before dropping
 func (prod *Spooling) TryFallback(msg *core.Message) {
 	if prod.revertOnDrop {
 		msg.SetStreamID(msg.GetPrevStreamID())
 	}
 	prod.BufferedProducer.TryFallback(msg)
+}
+
+func (prod *Spooling) encode(msg *core.Message) ([]byte, error) {
+	serialized, err := msg.Serialize()
+	if err != nil {
+		return nil, err
+	}
+
+	encodedLen := base64.StdEncoding.EncodedLen(len(serialized)) + 1
+	encoded := make([]byte, encodedLen)
+
+	base64.StdEncoding.Encode(encoded, serialized)
+	encoded[encodedLen-1] = '\n'
+
+	return encoded, nil
 }
 
 func (prod *Spooling) writeToFile(msg *core.Message) {
@@ -192,6 +192,16 @@ func (prod *Spooling) writeToFile(msg *core.Message) {
 		prod.TryFallback(msg)
 		return // ### return, could not spool to disk ###
 	}
+
+	// Convert to expected payload format
+	encodedPayload, err := prod.encode(msg)
+	if err != nil {
+		prod.Logger.WithError(err).Error("Failed to encoded messager for spooling")
+		prod.TryFallback(msg)
+		return // ### return, could not spool to disk ###
+	}
+
+	msg.StorePayload(encodedPayload)
 
 	// Append to buffer
 	spool.batch.AppendOrFlush(msg, spool.flush, prod.IsActiveOrStopping, prod.TryFallback)


### PR DESCRIPTION
## The purpose of this pull request

Since 0.5.0, the spooling format is broken, as messages are written to the spool file in plaintext and not as base64 encoded protobuf. 

## Config to verify

```yaml
"Generator":
    Type: "consumer.Profiler"
    Streams: "profile"
    Runs: 1000000
    Batches: 1000
    Characters: "abcdefghijklmnopqrstuvwxyz .,!;:-_"
    Message: "%256s"

"SocketOut":
    Type: "producer.Socket"
    Streams: "profile"
    ChannelTimeoutMs: 10
    Address: "127.0.0.1:5880"
    Modulators: 
        - "format.Runlength"
    ConnectionBufferSizeKB: 128
    FallbackStream: "spooling"
    Batch:
        TimeoutSec: 1
    Acknowledge: "OK"

"Spooler":
    Type: "producer.Spooling"
    Streams: "spooling"
    Path: "test"
    MaxFileSizeMB: 512```
```

## Checklist

- [x] `make test` executed successfully
- [ ] integration test provided
