### PR TITLE
Add optional release version suffix

### DIFF
--- a/docs/src/instructions/bestPractice.rst
+++ b/docs/src/instructions/bestPractice.rst
@@ -36,8 +36,17 @@ You can also copy the existing `contrib_loader.go.dist` to `contrib_loader.go` a
 
     cp contrib_loader.go.dist contrib_loader.go
     # open contrib_loader.go with an editor
-    # update package path
-    make current
+    # update package path with your plugin's path
+    make build
+
+You can also change the version string of you Gollum builds to include the version of your plugin.
+Set the GOLLUM_RELEASE_SUFFIX variable either in the environment or as an argument to ``make``:
+
+.. code-block:: bash
+
+    # build Gollum with myPackage version suffixed to the Gollum version
+    # e.g.: 0.5.3-pkg0a01d7b6
+    make all GOLLUM_RELEASE_SUFFIX=pkg$(git -C contrib/myPackage describe --tags --always)
 
 
 Use more Gollum processes for complex pipelines

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@
 GOLLUM_TAG := $(shell git describe --always --tags --match "v*" | sed -E 's/^v([0-9\.]+)(-[0-9]+){0,1}((-)g([a-f0-9]+)){0,1}.*/\1\2\4\5/')
 GOLLUM_RELEASE_SUFFIX := # Can be set for custom releases to also include plugin versions
 GOLLUM_DIRTY := $(if $(shell git status --porcelain),-dirty)
-GOLLUM_VERSION := $(GOLLUM_TAG)$(GOLLUM_DIRTY)$(if $(GOLLUM_RELEASE_SUFFIX),-$(GOLLUM_RELEASE_SUFFIX))
+GOLLUM_VERSION := $(GOLLUM_TAG)$(GOLLUM_DIRTY)$(if $(GOLLUM_RELEASE_SUFFIX),+$(GOLLUM_RELEASE_SUFFIX))
 
 GO_ENV := GORACE="halt_on_error=0"
 GO_FLAGS := -ldflags="-s -X 'github.com/trivago/gollum/core.versionString=$(GOLLUM_VERSION)'"

--- a/makefile
+++ b/makefile
@@ -1,8 +1,9 @@
 .DEFAULT_GOAL := help
 
 GOLLUM_TAG := $(shell git describe --always --tags --match "v*" | sed -E 's/^v([0-9\.]+)(-[0-9]+){0,1}((-)g([a-f0-9]+)){0,1}.*/\1\2\4\5/')
+GOLLUM_RELEASE_SUFFIX := # Can be set for custom releases to also include plugin versions
 GOLLUM_DIRTY := $(if $(shell git status --porcelain),-dirty)
-GOLLUM_VERSION := $(join $(GOLLUM_TAG),$(GOLLUM_DIRTY))
+GOLLUM_VERSION := $(GOLLUM_TAG)$(GOLLUM_DIRTY)$(if $(GOLLUM_RELEASE_SUFFIX),-$(GOLLUM_RELEASE_SUFFIX))
 
 GO_ENV := GORACE="halt_on_error=0"
 GO_FLAGS := -ldflags="-s -X 'github.com/trivago/gollum/core.versionString=$(GOLLUM_VERSION)'"

--- a/makefile
+++ b/makefile
@@ -74,7 +74,7 @@ install: build
 .PHONY: clean # Remove all files created by build and distribution targets
 clean:
 	@rm -f ./gollum
-	@rm -f ./dist/gollum_*.zip
+	@rm -f ./dist/gollum-*.zip
 	@go clean
 
 #############################################################################################################


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

## The purpose of this pull request

<!-- Please describe what this pull request fix or change -->
To make it easier for users of gollum to build their custom versions that can also include the versions of their own plugins without manually adding to the gollum version as defined in git and the Makefile.

We are already using this, I just forgot to make a PR last year. Sorry 😞

## Config to verify

```
make all GOLLUM_RELEASE_SUFFIX=1.2.3
make all
```
<!--- Provide a config to verify/test this pull request -->


## Checklist
<!--
Mark everything that applies:
-->

- [x] `make test` executed successfully
- [ ] unit test provided
- [ ] integration test provided
- [x] docs updated
