### PR TITLE
Fix ReStructuredText syntax in bestPractice.rst

### DIFF
--- a/docs/src/instructions/bestPractice.rst
+++ b/docs/src/instructions/bestPractice.rst
@@ -43,6 +43,7 @@ You can also change the version string of you Gollum builds to include the versi
 Set the GOLLUM_RELEASE_SUFFIX variable either in the environment or as an argument to ``make``:
 
 .. code-block:: bash
+
     # build Gollum with myPackage version suffixed to the Gollum version
     # e.g.: 0.5.3-pkg0a01d7b6
     make all GOLLUM_RELEASE_SUFFIX=pkg$(git -C contrib/myPackage describe --tags --always)


### PR DESCRIPTION
## The purpose of this pull request

A directive is expecting flags following in the very next line. The body has to be separated with at least one empty line.

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->


## Checklist
<!--
Mark everything that applies:
-->

- [ ] `make test` executed successfully
- [ ] unit test provided
- [ ] integration test provided
- [x] docs updated
