### PR TITLE
docs: fix codeblock in examples/helloWorld.rst

### DIFF
--- a/docs/src/examples/helloWorld.rst
+++ b/docs/src/examples/helloWorld.rst
@@ -214,17 +214,16 @@ Make sure to start Gollum with `gollum -ll 3 -ps` to see all log messages as wel
 
 ::
 
-'Profiler':
-  Type: 'consumer.Profiler'
-  Streams: 'profile'
-  Runs: 100000
-  Batches: 100
-  Characters: 'abcdefghijklmnopqrstuvwxyz .,!;:-_'
-  Message: '%256s'
-  KeepRunning: false
-  ModulatorRoutines: 0
+  'Profiler':
+    Type: 'consumer.Profiler'
+    Streams: 'profile'
+    Runs: 100000
+    Batches: 100
+    Characters: 'abcdefghijklmnopqrstuvwxyz .,!;:-_'
+    Message: '%256s'
+    KeepRunning: false
+    ModulatorRoutines: 0
 
-'Benchmark':
-  Type: 'producer.Benchmark'
-  Streams: 'profile'
-
+  'Benchmark':
+    Type: 'producer.Benchmark'
+    Streams: 'profile'


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

## The purpose of this pull request

Fix invalidly indented code block in one of the doc files
